### PR TITLE
Add CI workflow to run tasks end-to-end

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,18 @@
+name: End-to-end - data gen + tests on all platforms
+
+on:
+  workflow_run:
+    workflows:
+      - "Run Node JS tests"
+      - "Run Rust tests"
+    branches: [main]
+    types: 
+      - completed
+
+jobs:
+  run_all:
+    name: Gen data + run tests (generateAndRun.sh)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sh generateDataAndRun.sh

--- a/.github/workflows/gcs-upload.yml
+++ b/.github/workflows/gcs-upload.yml
@@ -1,23 +1,23 @@
 ##### README #####
 #
 # The CI action in this file is used to build the artifacts on pushes to a repository containing
-# the ICU4X service account key. All steps are skipped unless the key is present.
+# the Conformance service account key. All steps are skipped unless the key is present.
 #
 # If you are a frequent contributor, you can add the key to your fork. The key is shared with
-# icu4x collaborators and can be viewed here:
+# Conformance collaborators and can be viewed here:
 #
 # https://drive.google.com/file/d/1Of-_83MbhiiQAHYL_a5jDotOD9jnbu5c/view
 #
 # To add the key, follow these steps:
 #
 # 1. Go to the secrets on your fork:
-#     - https://github.com/{USER}/icu4x/settings/secrets/actions
+#     - https://github.com/{USER}/conformance/settings/secrets/actions
 # 2. Click "New repository secret" and enter the following information:
-#     - Name: ICU4X_GCP_SA_KEY
+#     - Name: CONFORMANCE_GCP_SA_KEY
 #     - Value: The contents of the file linked above
 # 3. Click "Add secret"
 # 4. Re-run the latest "Artifacts Build" action on your fork to make sure it works:
-#     - https://github.com/{USER}/icu4x/actions/workflows/artifacts-build.yml
+#     - https://github.com/{USER}/conformance/actions/workflows/gcs-upload.yml
 
 on:
   push:

--- a/.github/workflows/gcs-upload.yml
+++ b/.github/workflows/gcs-upload.yml
@@ -1,3 +1,5 @@
+name: Artifacts Build
+
 ##### README #####
 #
 # The CI action in this file is used to build the artifacts on pushes to a repository containing
@@ -21,8 +23,10 @@
 
 on:
   push:
+    branches: [ main ]
+  pull_request:
+    branches: '*'
 
-name: Artifacts Build
 
 jobs:
   credentials:

--- a/.github/workflows/run-nodejs.yml
+++ b/.github/workflows/run-nodejs.yml
@@ -2,7 +2,7 @@ on:
   push:
   pull_request:
 
-name: Run Node sample tests
+name: Run Node JS tests
 
 jobs:
   nodejs_18:

--- a/.github/workflows/run-nodejs.yml
+++ b/.github/workflows/run-nodejs.yml
@@ -1,8 +1,10 @@
+name: Run Node JS tests
+
 on:
   push:
+    branches: [ main ]
   pull_request:
-
-name: Run Node JS tests
+    branches: '*'
 
 jobs:
   nodejs_18:

--- a/.github/workflows/run-rust.yml
+++ b/.github/workflows/run-rust.yml
@@ -8,7 +8,7 @@ on:
     - 'executors/rust/**'
     - '.github/**'
 
-name: Rust CI
+name: Run Rust tests
 
 jobs:
   rust_lint:

--- a/.github/workflows/run-rust.yml
+++ b/.github/workflows/run-rust.yml
@@ -1,14 +1,10 @@
+name: Run Rust tests
+
 on:
   push:
-    paths:
-    - 'executors/rust/**'
-    - '.github/**'
+    branches: [ main ]
   pull_request:
-    paths: 
-    - 'executors/rust/**'
-    - '.github/**'
-
-name: Run Rust tests
+    branches: '*'
 
 jobs:
   rust_lint:


### PR DESCRIPTION
Fixes #39 

- Adds new workflow to run everything, but only after each set of tests per language/platform succeeds
- Also refactor existing CI workflows in small ways to make more consistent