### PR TITLE
Fix num options

### DIFF
--- a/executors/node/executor.js
+++ b/executors/node/executor.js
@@ -177,6 +177,11 @@ rl.on('line', function(line) {
                     'unsupported_test': testId};
     }
 
+    if ('error' in outputLine) {
+      // To get the attention of the driver
+      console.log("#!! ERROR in NODE call: " + JSON.stringify(outputLine));
+    }
+
     // Send result to stdout for verification
     jsonOut = JSON.stringify(outputLine);
     process.stdout.write(jsonOut + '\n');

--- a/executors/node/langnames.js
+++ b/executors/node/langnames.js
@@ -7,13 +7,13 @@ module.exports = {
     let options = {};
     if (json['locale_label']) {
       // Fix to use dash, not underscore.
-      locale = json['locale_label'].replaceAll('_', '-');
+      locale = json['locale_label'].replace(/_/g, '-');
     }
 
     // options = json['options'];
     options = {'type': 'language'};
     let label = json['label'];
-    let input = json['language_label'].replaceAll('_', '-');
+    let input = json['language_label'].replace(/_/g, '-');
 
     let outputLine;
     //console.log("langnames input: " + input +

--- a/executors/node/langnames.js
+++ b/executors/node/langnames.js
@@ -19,7 +19,22 @@ module.exports = {
     //console.log("langnames input: " + input +
     //            " options: " + JSON.stringify(options) + " locale " + locale);
 
-    const dn = new Intl.DisplayNames([locale], options);
+    let dn;
+    try {
+      dn = new Intl.DisplayNames([locale], options);
+    } catch (error) {
+      outputLine = {
+        "error": error.toString(),
+        "label": json['label'],
+        "locale_label": locale,
+        "language_label": input,
+        "test_type": "display_names",
+        "error_type": "unsupported",
+        "error_retry": false  // Do not repeat
+      };
+      return outputLine;
+    }
+
     let resultString;
     try {
       resultString = dn.of(input);

--- a/testdriver/datasets.py
+++ b/testdriver/datasets.py
@@ -177,8 +177,8 @@ NodeICUVersionMap = {
     "14": "70.1",
     }
 
-# For Rust
-RustICUVersionMap = {
+# Versions of ICU in each ICU4X release
+ICU4XVersionMap = {
     # TODO: fill this in
     "1.0": '71.1'
 }

--- a/testdriver/datasets.py
+++ b/testdriver/datasets.py
@@ -172,14 +172,16 @@ class ICU4XVersion(Enum):
 # What versions of NodeJS use specific ICU versions
 # https://nodejs.org/en/download/releases/
 NodeICUVersionMap = {
-    "19.7.0": "72.1",
-    "18.14.2": "72.1",
-    "17.9.1": "70.1",
-    "16.19.1": "71.1",
-    "16.1.0": "69.1",
-    "15.14.0": "68.1",
-    "13.14.0": "66.1",
+    "18": "72.1",
+    "16": "71.1",
+    "14": "70.1",
     }
+
+# For Rust
+RustICUVersionMap = {
+    # TODO: fill this in
+    "1.0": '71.1'
+}
 
 # Executor programs organized by langs and version
 class ExecutorInfo():

--- a/testdriver/ddtargs.py
+++ b/testdriver/ddtargs.py
@@ -121,6 +121,15 @@ def setCommonArgs(parser):
   parser.add_argument('--parallel_mode', default=None)
   parser.add_argument('--run_limit', default=None)
 
+  # Arguments for setting versions of executors
+  parser.add_argument('--node_version', default='node')  # Sets the version of node to test
+  parser.add_argument('--rust_version', default='latest')
+  parser.add_argument('--icu4c_version', default='latest')
+  parser.add_argument('--icu4j_version', default='latest')
+
+  # Base version to test on version of ICU requested
+  parser.add_argument('--icu_version', default='latest')
+
   parser.add_argument(
       '--custom_testfile', default=None, action='extend', nargs='*',
       help='full path to test data file in JSON format')

--- a/testdriver/ddtargs.py
+++ b/testdriver/ddtargs.py
@@ -123,7 +123,7 @@ def setCommonArgs(parser):
 
   # Arguments for setting versions of executors
   parser.add_argument('--node_version', default='node')  # Sets the version of node to test
-  parser.add_argument('--rust_version', default='latest')
+  parser.add_argument('--icu4x_version', default='latest')
   parser.add_argument('--icu4c_version', default='latest')
   parser.add_argument('--icu4j_version', default='latest')
 

--- a/testdriver/testplan.py
+++ b/testdriver/testplan.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import json
 import os
 import subprocess
+import re
 import sys
 import time
 
@@ -67,6 +68,15 @@ class TestPlan():
       # !!!
       x = 1
 
+    # Check for option to set version of executor
+    # TODO
+
+    if self.test_lang == 'node' and 'node_version' in self.options:
+      # Set up for the version of node selected
+      nvm_command = 'nvm use %s' % self.options.node_version
+      result = subprocess.run(['bash', '-c', nvm_command])
+
+
     self.inputFilePath = os.path.join(self.options.file_base,
                                       self.options.input_path,
                                       self.testData.testDataFilename)
@@ -75,6 +85,7 @@ class TestPlan():
     output_dir = self.test_lang
     self.outputFilePath = os.path.join(self.options.file_base,
                                        self.options.output_path,
+                                       self.platformVersion,
                                        output_dir,
                                       self.testData.testDataFilename)
     self.verifyFilePath = os.path.join(self.options.file_base,
@@ -119,6 +130,14 @@ class TestPlan():
       try:
         self.jsonOutput["platform"] = json.loads(result)
         self.platformVersion =  self.jsonOutput["platform"]["platformVersion"]
+        self.icuVersion =  self.jsonOutput["platform"]["icuVersion"]
+
+        # Reset the output patch based on the version.
+        self.outputFilePath = os.path.join(self.options.file_base,
+                                           self.options.output_path,
+                                           self.test_lang,
+                                           self.platformVersion,
+                                           self.testData.testDataFilename)
       except:
         return None
     return True
@@ -178,28 +197,6 @@ class TestPlan():
             (self.exec_command, self.inputFilePath))
 
     # Set up calls for version data --> results
-    # Use for directory of the output results
-    self.requestExecutorInfo()
-
-    # Check if report directory exists
-    try:
-      result_dir = os.path.dirname(self.outputFilePath)
-      if not os.path.isdir(result_dir):
-        os.makedirs(result_dir)
-    except BaseException as err:
-      sys.stderr.write('!!! Cannot create directory %sfor report file %s' %
-                       (result_dir_dir, self.outputFilePath))
-      return None
-
-    # Create results file
-    try:
-      if self.debug:
-        print('++++++ Results file path = %s' % self.outputFilePath)
-      self.resultsFile = open(self.outputFilePath, encoding='utf-8', mode='w')
-    except BaseException as err:
-      print('*** Cannot open results file at %s. Err = %s' %
-            (self.outputFilePath, err))
-      # What do do in case of error?
 
     # Clear the JSON result for the new testing.
     self.jsonOutput ={}
@@ -224,6 +221,28 @@ class TestPlan():
     is_executor_ok = self.requestExecutorInfo()
     if not is_executor_ok:
       return None
+
+    # Use for directory of the output results
+    # Check if report directory exists
+    try:
+      result_dir = os.path.dirname(self.outputFilePath)
+      if not os.path.isdir(result_dir):
+        os.makedirs(result_dir)
+    except BaseException as err:
+      sys.stderr.write('!!! Cannot create directory %sfor report file %s' %
+                       (result_dir, self.outputFilePath))
+      return None
+
+    # Create results file
+
+    try:
+      if self.debug:
+        print('++++++ Results file path = %s' % self.outputFilePath)
+      self.resultsFile = open(self.outputFilePath, encoding='utf-8', mode='w')
+    except BaseException as err:
+      print('*** Cannot open results file at %s. Err = %s' %
+            (self.outputFilePath, err))
+      self.resultsFile = open(self.outputFilePath, encoding='utf-8', mode='w')
 
     # Store information the test run
     test_environment = self.generateHeader();
@@ -351,6 +370,7 @@ class TestPlan():
 
     index = 0
     batchOut = []
+    should_retry = True
     for item in result.split('\n'):
       if self.debug > 1:
         print(' RESULT %d = (%d)  >%s<' % (index, len(item), item))
@@ -358,6 +378,18 @@ class TestPlan():
         # Check for debug data
         if item[0] == "#":
           print('#### DEBUG OUTPUT = %s' % item)
+
+          # Process some types of errors
+          if item[1:3] == "!!":
+            print(" !!!!!!!!!!!!!!!!! ERROR: %s" % item)
+            # Extract the message and check if we continue or not.
+            json_start = item.index('{')
+            json_text = item[json_start:]
+            print('JSON TEXT = %s' % json_text)
+            json_out = json.loads(json_text)
+            if 'error_retry' in json_out and json_out['error_retry']:
+              should_retry = json_out['error_retury']
+              print('!!! SHOULD RETRY = %s' % should_retry)
         elif item != None and item != "":
             try:
               json_out = json.loads(item)

--- a/testdriver/testplan.py
+++ b/testdriver/testplan.py
@@ -132,7 +132,7 @@ class TestPlan():
         self.platformVersion =  self.jsonOutput["platform"]["platformVersion"]
         self.icuVersion =  self.jsonOutput["platform"]["icuVersion"]
 
-        # Reset the output patch based on the version.
+        # Reset the output path based on the version.
         self.outputFilePath = os.path.join(self.options.file_base,
                                            self.options.output_path,
                                            self.test_lang,
@@ -375,7 +375,10 @@ class TestPlan():
       if self.debug > 1:
         print(' RESULT %d = (%d)  >%s<' % (index, len(item), item))
       if item and len(item) > 0:
-        # Check for debug data
+        # Check for special results returned from the executor,
+        # indicated by '#' in the first column of the line returned.
+        # An error is indicated by "#!!" in the first 3 columns.
+        # TODO: Document these, perhaps in the project's JSON schema.        #
         if item[0] == "#":
           print('#### DEBUG OUTPUT = %s' % item)
 

--- a/testgen/numberpermutationtest.txt
+++ b/testgen/numberpermutationtest.txt
@@ -73,9 +73,9 @@ compact-short measure-unit/length-meter unit-width-narrow
 
 compact-short measure-unit/length-meter unit-width-full-name
   es-MX
-    0 meters
-    92 k meters
-    -0.22 meters
+    0 metros
+    92 k metros
+    -0.22 metros
   zh-TW
     0 公尺
     9.2萬 公尺
@@ -157,9 +157,9 @@ scientific/+ee/sign-always measure-unit/length-meter unit-width-narrow
 
 scientific/+ee/sign-always measure-unit/length-meter unit-width-full-name
   es-MX
-    0E+00 meters
-    9.182736E+04 meters
-    -2.2222E-01 meters
+    0E+00 metros
+    9.182736E+04 metros
+    -2.2222E-01 metros
   zh-TW
     0E+00 公尺
     9.182736E+04 公尺
@@ -3363,9 +3363,9 @@ measure-unit/length-meter unit-width-narrow @@
 
 measure-unit/length-meter unit-width-full-name precision-integer
   es-MX
-    0 meters
-    91,827 meters
-    -0 meters
+    0 metros
+    91,827 metros
+    -0 metros
   zh-TW
     0 公尺
     91,827 公尺
@@ -3377,9 +3377,9 @@ measure-unit/length-meter unit-width-full-name precision-integer
 
 measure-unit/length-meter unit-width-full-name .000
   es-MX
-    0.000 meters
-    91,827.364 meters
-    -0.222 meters
+    0.000 metros
+    91,827.364 metros
+    -0.222 metros
   zh-TW
     0.000 公尺
     91,827.364 公尺
@@ -3391,9 +3391,9 @@ measure-unit/length-meter unit-width-full-name .000
 
 measure-unit/length-meter unit-width-full-name .##/@@@+
   es-MX
-    0 meters
-    91,827.36 meters
-    -0.222 meters
+    0 metros
+    91,827.36 metros
+    -0.222 metros
   zh-TW
     0 公尺
     91,827.36 公尺
@@ -3405,9 +3405,9 @@ measure-unit/length-meter unit-width-full-name .##/@@@+
 
 measure-unit/length-meter unit-width-full-name @@
   es-MX
-    0.0 meters
-    92,000 meters
-    -0.22 meters
+    0.0 metros
+    92,000 metros
+    -0.22 metros
   zh-TW
     0.0 公尺
     92,000 公尺
@@ -3489,9 +3489,9 @@ measure-unit/length-meter unit-width-narrow rounding-mode-floor
 
 measure-unit/length-meter unit-width-full-name rounding-mode-floor
   es-MX
-    0 meters
-    91,827.3645 meters
-    -0.22222 meters
+    0 metros
+    91,827.3645 metros
+    -0.22222 metros
   zh-TW
     0 公尺
     91,827.3645 公尺
@@ -3573,9 +3573,9 @@ measure-unit/length-meter unit-width-narrow integer-width/##00
 
 measure-unit/length-meter unit-width-full-name integer-width/##00
   es-MX
-    00 meters
-    1,827.3645 meters
-    -00.22222 meters
+    00 metros
+    1,827.3645 metros
+    -00.22222 metros
   zh-TW
     00 公尺
     1,827.3645 公尺
@@ -3657,9 +3657,9 @@ measure-unit/length-meter unit-width-narrow scale/0.5
 
 measure-unit/length-meter unit-width-full-name scale/0.5
   es-MX
-    0 meters
-    45,913.68225 meters
-    -0.11111 meters
+    0 metros
+    45,913.68225 metros
+    -0.11111 metros
   zh-TW
     0 公尺
     45,913.68225 公尺
@@ -3741,9 +3741,9 @@ measure-unit/length-meter unit-width-narrow group-on-aligned
 
 measure-unit/length-meter unit-width-full-name group-on-aligned
   es-MX
-    0 meters
-    91,827.3645 meters
-    -0.22222 meters
+    0 metros
+    91,827.3645 metros
+    -0.22222 metros
   zh-TW
     0 公尺
     91,827.3645 公尺
@@ -3825,9 +3825,9 @@ measure-unit/length-meter unit-width-narrow latin
 
 measure-unit/length-meter unit-width-full-name latin
   es-MX
-    0 meters
-    91,827.3645 meters
-    -0.22222 meters
+    0 metros
+    91,827.3645 metros
+    -0.22222 metros
   zh-TW
     0 公尺
     91,827.3645 公尺
@@ -3909,9 +3909,9 @@ measure-unit/length-meter unit-width-narrow sign-accounting-except-zero
 
 measure-unit/length-meter unit-width-full-name sign-accounting-except-zero
   es-MX
-    0 meters
-    +91,827.3645 meters
-    -0.22222 meters
+    0 metros
+    +91,827.3645 metros
+    -0.22222 metros
   zh-TW
     0 公尺
     +91,827.3645 公尺
@@ -3993,9 +3993,9 @@ measure-unit/length-meter unit-width-narrow decimal-always
 
 measure-unit/length-meter unit-width-full-name decimal-always
   es-MX
-    0. meters
-    91,827.3645 meters
-    -0.22222 meters
+    0. metros
+    91,827.3645 metros
+    -0.22222 metros
   zh-TW
     0. 公尺
     91,827.3645 公尺

--- a/testgen/testdata_gen.py
+++ b/testgen/testdata_gen.py
@@ -11,7 +11,7 @@ reblankline = re.compile('^\s*$')
 
 # Global constants
 # Values to be formatted in number format tests
-# NUMBERS_TO_TEST = ['0', '91827.3645', '-0.22222']
+NUMBERS_TO_TEST = ['0', '91827.3645', '-0.22222']
 
 # Which locales are selected for this testing.
 # This selects es-MX, zh-TW, bn-BD

--- a/testgen/testdata_gen.py
+++ b/testgen/testdata_gen.py
@@ -35,47 +35,46 @@ def parseDcmlFmtTestData(rawtestdata):
 
 def mapFmtSkeletonToECMA402(options):
   ecma402_map = {
-      "compact-short": '"notation": "compact",\n  "compactDisplay": "short",\n',
-      "scientific/+ee/sign-always": '"notation": "scientific",\n',
+      "compact-short": {"notation": "compact",  "compactDisplay": "short"},
+      "scientific/+ee/sign-always": {"notation": "scientific"},
       # Percent with word "percent":
-      #    {'style': 'unit', unit:'percent', 'unitDisplay': 'long'})
+      "percent": {"style": "unit", "unit": "percent"},  # "style": "percent",
+      "currency/EUR": {"style": "currency", "currencyDisplay": "symbol",  "currency": "EUR"},
+      "measure-unit/length-meter": {"style": "unit",  "unit": "meter"},
+      #"measure-unit/length-furlong": {"style": "unit", "unit": "furlong"},
+      "unit-width-narrow": {"unitDisplay": "narrow", "currencyDisplay": "symbol"},
+      "unit-width-full-name": {"unitDisplay": "long", "currencyDisplay": "name"},
+      #"unit-width-full-name": {"unitDisplay": "long"},
+      "precision-integer": {"maximumFractionDigits": "0", "minimumFractionDigits": "0", "roundingType": "fractionDigits"},
+      ".000": {"maximumFractionDigits": "3", "minimumFractionDigits": "3"},
 
-      "percent": '"style": "unit", "unit": "percent"',  # "style": "percent",\n',
-      # "currency/EUR": '"style": "currency",\n  "currencyDisplay": "code",\n  "code": "EUR",\n',
-      "currency/EUR": '"style": "currency",\n  "currencyDisplay": "symbol",\n  "code": "EUR",\n',
-      "measure-unit/length-meter": '"style": "unit",\n  "unit": "meter",\n',
-      #"measure-unit/length-furlong": '"style": "unit",\n  "unit": "furlong",\n',
-      "unit-width-narrow": '"unitDisplay": "narrow",\n',
-      "unit-width-full-name": '"unitDisplay": "long",\n',
-      #"unit-width-full-name": '"unitDisplay": "long",\n',
-      "precision-integer": '"maximumFractionDigits": "0",\n  "minimumFractionDigits": "0",\n  "roundingType": "fractionDigits",\n',
-      ".000": '"maximumFractionDigits": "3",\n  "minimumFractionDigits": "3",\n',
-      ".##/@@@+": '"maximumFractionDigits": "2",\n  "minimumSignificantDigits": "3",\n',
-      "@@": '"maximumSignificantDigits": "2",\n  "minimumSignificantDigits": "2",\n',
-      "rounding-mode-floor": '"roundingMode": "floor",\n',
-      "integer-width/##00": '"maximumIntegerDigits": "4",\n  "minimumIntegerDigits":"2",\n',
-      "group-on-aligned": '"useGrouping": "true",\n',
-      "latin": '"numberingSystem": "latn",\n',
-      "sign-accounting-except-zero": '"signDisplay": "exceptZero",\n',
-      "0.0000E0": '"notation": "scientific",\n  "minimumIntegerDigits": "1",\n  "minimumFractionDigits": "4",\n  "maximumFractionDigits": "4",\n',
-      "00": '"minimumIntegerDigits":"2",\n',
-      "#.#": '"maximumFractionDigits": "1",\n',
-      "@@@": '"minimumSignificantDigits": "3",\n  "maximumSignificantDigits": "3",\n',
-      "@@###": '"minimumSignificantDigits": "2",\n  "maximumSignificantDigits": "5",\n',
-      "@@@@E0": '"notation": "scientific",\n  "minimumSignificantDigits": "4",\n  "maximumSignificantDigits": "4",\n',
-      "0.0##E0": '"notation": "scientific",\n  "minimumIntegerDigits":"1",\n  "minimumFractionDigits": "1",\n  "maximumFractionDigits": "3",\n',
-      "00.##E0": '"notation": "scientific",\n  "minimumIntegerDigits":"2",\n  "minimumFractionDigits": "1",\n  "maximumFractionDigits": "3",\n',
-      "0005": '"minimumIntegerDigits":"2",\n',
-      "0.00": '"minimumIntegerDigits":"1",\n  "minimumFractionDigits": "2",\n  "maximumFractionDigits": "2",\n',
-      "0.000E0": '"notation": "scientific",\n  "minimumIntegerDigits":"1",\n  "minimumFractionDigits": "3",\n  "maximumFractionDigits": "3",\n',
-      "0.0##": '"minimumIntegerDigits":"1",\n  "minimumFractionDigits": "1",\n  "maximumFractionDigits": "3",\n',
-      "#": '"minimumIntegerDigits":"1",\n  "maximumFractionDigits": "0",\n',
-      "0.#E0": '"notation": "scientific",\n  "minimumIntegerDigits":"1",\n  "maximumFractionDigits": "1",\n',
-      "0.##E0": '"notation": "scientific",\n  "minimumIntegerDigits":"1",\n  "maximumFractionDigits": "2",\n',
-      ".0E0": '"notation": "scientific",\n  "minimumIntegerDigits":"0",\n  "minimumFractionDigits": "1",\n  "maximumFractionDigits": "1",\n',
-      ".0#E0": '"notation": "scientific",\n  "minimumIntegerDigits":"0",\n  "minimumFractionDigits": "1",\n  "maximumFractionDigits": "2",\n',
-      "@@@@@@@@@@@@@@@@@@@@@@@@@": '"minimumSignificantDigits": "25",\n  "maximumSignificantDigits": "25",\n',
-      "0.0": '"minimumIntegerDigits":"1",\n  "minimumFractionDigits": "2",\n  "maximumFractionDigits": "2",\n'
+      # Use maximumFractionDigits: 2, maximumSignificantDigits: 3, roundingPriority: "morePrecision"
+      ".##/@@@+": {"maximumFractionDigits": "2", "maximumSignificantDigits": "3","roundingPriority": "morePrecision"},
+      "@@": {"maximumSignificantDigits": "2", "minimumSignificantDigits": "2"},
+      "rounding-mode-floor": {"roundingMode": "floor"},
+      "integer-width/##00": {"maximumIntegerDigits": "4", "minimumIntegerDigits":"2"},
+      "group-on-aligned": {"useGrouping": "true"},
+      "latin": {"numberingSystem": "latn"},
+      "sign-accounting-except-zero": {"signDisplay": "exceptZero"},
+      "0.0000E0": {"notation": "scientific", "minimumIntegerDigits": "1", "minimumFractionDigits": "4", "maximumFractionDigits": "4"},
+      "00": {"minimumIntegerDigits":"2"},
+      "#.#": {"maximumFractionDigits": "1"},
+      "@@@": {"minimumSignificantDigits": "3", "maximumSignificantDigits": "3"},
+      "@@###": {"minimumSignificantDigits": "2", "maximumSignificantDigits": "5"},
+      "@@@@E0": {"notation": "scientific", "minimumSignificantDigits": "4", "maximumSignificantDigits": "4"},
+      "0.0##E0": {"notation": "scientific", "minimumIntegerDigits":"1", "minimumFractionDigits": "1", "maximumFractionDigits": "3"},
+      "00.##E0": {"notation": "scientific", "minimumIntegerDigits":"2", "minimumFractionDigits": "1", "maximumFractionDigits": "3"},
+      "0005": {"minimumIntegerDigits":"2"},
+      "0.00": {"minimumIntegerDigits":"1", "minimumFractionDigits": "2", "maximumFractionDigits": "2"},
+      "0.000E0": {"notation": "scientific", "minimumIntegerDigits":"1", "minimumFractionDigits": "3", "maximumFractionDigits": "3"},
+      "0.0##": {"minimumIntegerDigits":"1", "minimumFractionDigits": "1", "maximumFractionDigits": "3"},
+      "#": {"minimumIntegerDigits":"1", "maximumFractionDigits": "0"},
+      "0.#E0": {"notation": "scientific", "minimumIntegerDigits":"1", "maximumFractionDigits": "1"},
+      "0.##E0": {"notation": "scientific", "minimumIntegerDigits":"1", "maximumFractionDigits": "2"},
+      ".0E0": {"notation": "scientific", "minimumIntegerDigits":"0", "minimumFractionDigits": "1", "maximumFractionDigits": "1"},
+      ".0#E0": {"notation": "scientific", "minimumIntegerDigits":"0", "minimumFractionDigits": "1", "maximumFractionDigits": "2"},
+      "@@@@@@@@@@@@@@@@@@@@@@@@@": {"minimumSignificantDigits": "25", "maximumSignificantDigits": "25"},
+      "0.0": {"minimumIntegerDigits":"1", "minimumFractionDigits": "2", "maximumFractionDigits": "2"}
       }
 
   ecma402_options = []
@@ -85,21 +84,11 @@ def mapFmtSkeletonToECMA402(options):
   # Look at the expected output...
   for o in options:
     if o != 'scale/0.5' and o != 'decimal-always':
-      options_str = ecma402_map[o]
-      ecma402_options.append(ecma402_map[o])
-      options_split = options_str.split(',\n')
-      for item in options_split:
-        if not item:
-            continue
-        try:
-          text = item[1:-1].replace('"', '')
-          details = text.split(':')
-          options_dict[details[0].strip()] = details[1].replace('"', '').strip()
-        except IndexError:
-          print('FAIL WITH DETAILS: %s in options_split: %s' % (item, options_split))
+      option_detail = ecma402_map[o]
+      options_dict = options_dict | option_detail
 
    # TODO: resolve some combinations of entries that are in conflict
-  return ecma402_options, options_dict
+  return  options_dict
 
 
 def mapRoundingToECMA402(rounding):
@@ -208,7 +197,6 @@ def generateNumberFmtTestDataObjects(rawtestdata, count=0):
         ecma402_options = []
         label = str(count).rjust(7, '0')
         expected = t[l + 1 + n]
-        verifydata = '{\n  "label": "%s",\n  "verify": "%s"\n},' % (str(count).rjust(7, '0'), t[l + 1 + n])
         verify_json = {'label': label, 'verify': expected}
         verify_list.append(verify_json)
 
@@ -220,9 +208,7 @@ def generateNumberFmtTestDataObjects(rawtestdata, count=0):
                  'input': numbers_to_test[n]
                  }
 
-        entry_top = '{\n  "label": "%s",\n  "locale": "%s",\n  "skeleton": "%s %s %s",\n' % (str(count).rjust(7, '0'), t[l], t[0], t[1], t[2])
-        entry_bottom = '"input": "%s"\n},' % numbers_to_test[n]
-        ecma402_options_body, options_dict = mapFmtSkeletonToECMA402([t[0], t[1], t[2]])
+        options_dict = mapFmtSkeletonToECMA402([t[0], t[1], t[2]])
         if not options_dict:
             print(
                 '$$$ OPTIONS not found for %s' % label
@@ -232,16 +218,6 @@ def generateNumberFmtTestDataObjects(rawtestdata, count=0):
         # include these options in the entry
         entry = entry | {'options': resolved_options_dict}
 
-        # TODO: add resolved options to entry as json.
-
-        # Remove comma after last entry, add closing bracket.
-        (start, comma, end) = ecma402_options_body[-1].rpartition(',')
-        ecma402_options_body[-1] = start + '\n},' + end
-        ecma402_options = ecma402_options_start +  ecma402_options_body   # mapFmtSkeletonToECMA402([t[0], t[1], t[2]])
-        ecma402_jobj = ''.join(ecma402_options)
-        ecma402_entry = [entry_top] + insertJObj(ecma402_options, 2) + [entry_bottom]
-
-        # Use the entry rather than the string here
         all_tests_list.append(entry)  # All the tests in JSON form
         count += 1
 
@@ -258,6 +234,7 @@ def resolveOptions(raw_options, skeleton_list):
     resolved['style'] = 'unit'
     resolved['unit'] = 'percent'
     if 'unit-width-full-name' in skeleton_list:
+        resolved['currencyDisplay'] = 'name'
         resolved['unitDisplay'] = 'long'
   return resolved
 
@@ -274,7 +251,7 @@ def generateDcmlFmtTestDataObjects(rawtestdata, count=0):
       label = str(count).rjust(7, '0')
       entry = {'label': label, 'op': 'format', 'skeleton': pattern , 'input': test_input, 'options': {} }
 
-      pattern_part, json_part = mapFmtSkeletonToECMA402([pattern])
+      json_part = mapFmtSkeletonToECMA402([pattern])
 
       resolved_options_dict = resolveOptions(json_part, None)
 
@@ -507,11 +484,10 @@ def processLangNameTestData():
 def main():
   print('Generating .json files for data driven testing')
 
+  processNumberFmtTestData()
   processLangNameTestData()
 
   processCollationTestData()
-
-  processNumberFmtTestData()
 
   print('================================================================================')
 

--- a/testgen/testdata_gen.py
+++ b/testgen/testdata_gen.py
@@ -9,6 +9,15 @@ import sys
 
 reblankline = re.compile('^\s*$')
 
+# Global constants
+# Values to be formatted in number format tests
+# NUMBERS_TO_TEST = ['0', '91827.3645', '-0.22222']
+
+# Which locales are selected for this testing.
+# This selects es-MX, zh-TW, bn-BD
+NUMBERFORMAT_LOCALE_INDICES = [3, 7, 11]
+
+
 # Utility functions
 def computeMaxDigitsForCount(count):
     return math.ceil(math.log10(count + 1))
@@ -186,17 +195,12 @@ def generateNumberFmtTestDataObjects(rawtestdata, count=0):
       "sign-accounting-except-zero": "sign-display",
       "decimal-always": "decimal-separator-display"
       }
-  NUMBERS_TO_TEST = ['0', '91827.3645', '-0.22222']
   test_list = parseNumberFmtTestData(rawtestdata)
   ecma402_options_start = ['"options": {\n']
 
   all_tests_list = []
   verify_list = []
-  
-  # Which locales are selected for this testing.
-  # This selects es-MX, zh-TW, bn-BD
-  NUMBERFORMAT_LOCALE_INDICES = [3, 7, 11]
-  
+
   expected_count = len(test_list) * len(NUMBERFORMAT_LOCALE_INDICES) * len(NUMBERS_TO_TEST) + count
   max_digits = computeMaxDigitsForCount(expected_count)
   logging.info('  Expected count  of number fmt tests: %s', expected_count)

--- a/verifier/report_template.py
+++ b/verifier/report_template.py
@@ -104,7 +104,26 @@ class reportTemplate():
         }
       }
     }
-    </script>
+
+    function loadJson(json_data) {
+
+    }
+
+    // Get up the JSON data from the tests.
+    let pass_json;
+    let fail_json;
+    let error_json;
+    let unsupported_json;
+
+    fetch('./pass/pass.json')
+      .then((response) => pass_json = response.json());
+    fetch('./failing_tests/failing_tests.json')
+      .then((response) => fail_json = response.json());
+    fetch('./test_errors/test_errors.json')
+      .then((response) => error_json = response.json());
+    fetch('./unsupported/unsupported.json')
+      .then((response) => unsupportd_json = response.json());
+</script>
   </head>
   <body>
     <h1>Verification report: $test_type on $exec</h1>
@@ -120,7 +139,10 @@ class reportTemplate():
     <h2>Test summary</h2>
     <p>Total: $total_tests.
     <p>Pass: $passing_tests, Fail: $failing_tests, Errors: $error_count, Unsupported: $unsupported_count</p>
-    <h2 id='testErrors'">Test Errors ($error_count)</h2>
+    <h2 id='passingTests'>Passing tests</h2>
+    <button onclick="loadJson('./pass/pass.json')">Load passing tests</button>
+
+    <h2 id='testErrors'>Test Errors ($error_count)</h2>
     <h3>Summary of test errors</h3>
     $error_summary
     <details>

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -682,7 +682,10 @@ class SummaryReport():
       filename_base = filename.rpartition('.')[0]
       dir_path = os.path.dirname(filename_base)
       html_name = os.path.basename(filename_base) + '.html'
+      # Get the relative path for the link
       html_path = os.path.join(dir_path, html_name)
+      reports_base_dir = os.path.join(self.file_base, self.report_dir_name)
+      relative_html_path = os.path.relpath(html_path, reports_base_dir)
       test_json = json.loads(file.read())
 
       test_environment = test_json['test_environment']
@@ -703,7 +706,7 @@ class SummaryReport():
             'error_count': test_json['test_error_count'],
             'missing_verify_count': len(test_json['missing_verify_data']),
             'json_file_name': filename,
-            'html_file_name': html_path,
+            'html_file_name': relative_html_path,  # Relative to the report base
             'version': test_json['platform']
         }
 

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -625,8 +625,10 @@ class SummaryReport():
   def getJsonFiles(self):
     # For each executor directory in testReports,
     #  Get each json report file
+    self.version_directories = glob.glob(
+      os.path.join(self.file_base, self.report_dir_name, '*', '*'))
     self.raw_reports = glob.glob(
-        os.path.join(self.file_base, self.report_dir_name, '*', '*.json'))
+        os.path.join(self.file_base, self.report_dir_name, '*', '*', '*.json'))
     if self.debug > 1:
       print('SUMMARY JSON RAW FILES = %s' % (self.raw_reports))
     return self.raw_reports

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -237,11 +237,7 @@ class TestReport():
       dir_name = self.report_directory
       category_dir_name = os.path.join(dir_name, category)
 
-      try:
-        os.makedirs(category_dir_name)  # Creates the full directory path.
-      except:
-        # OK if this already exists
-        pass
+      os.makedirs(category_dir_name, exist_ok=True)  # Creates the full directory path.
 
       # In that directory, create a file or files for the category output as JSON
       output_name = os.path.join(category_dir_name, category + ".json")  # TODO: Change to a list of files

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -430,7 +430,9 @@ class TestReport():
     results['insert_digit'] = []
     results['insert_space'] = []
     results['delete_digit'] = []
+    results['exponent_diff'] = []
     for fail in self.failing_tests:
+      label = fail['label']
       actual = fail['result']
       expected = fail['expected']
       # Special case for differing by a single character.
@@ -452,19 +454,24 @@ class TestReport():
             for x in changes:
               if x[0] == '+':
                 if x[2] in [' ', '\u00a0']:
-                  results['insert_space'].append(fail['label'])
+                  results['insert_space'].append(label)
                 elif x[2].isdigit():
-                  results['insert_digit'].append(fail['label'])
+                  results['insert_digit'].append(label)
+                elif x[2] in ['+', '0', '+0']:
+                  results['exponent_diff'] = append(label)
                 else:
-                  results['insert'].append(fail['label'])
+                  results['insert'].append(label)
               if x[0] == '-':
                 if x[2].isdigit():
                   results['delete_digit'].append(fail['label'])
+                elif x[2] in ['+', '0', '+0']:
+                  results['exponent_diff'] = append(label)
                 else:
                   results['delete'].append(fail['label'])
       except BaseException as err:
         # a non-string result
         continue
+
     return dict(results)
 
   def create_html_diff_report(self):
@@ -680,7 +687,7 @@ class SummaryReport():
     outList.append('Test count: %s' % entry['test_count'])
     outList.append('Succeeded: %s' % entry['pass_count'])
     outList.append('Failed: %s' % entry['fail_count'])
-    outList.append('Errors: %s' % entry['error_count'])
+    outList.append('Unsupported: %s' % entry['error_count'])
     outList.append('Missing verify: %s' % entry['missing_verify_count'])
     outList.append('<a href="%s"  target="_blank">Details</a>' %
                    entry['html_file_name'])

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -236,16 +236,13 @@ class TestReport():
     for category, case_list in categories.items():
       dir_name = self.report_directory
       category_dir_name = os.path.join(dir_name, category)
+
       try:
-        os.mkdir(dir_name)
-      except FileExistsError:
-        # It's OK if the directory is already there.
+        os.makedirs(category_dir_name)  # Creates the full directory path.
+      except:
+        # OK if this already exists
         pass
-      try:
-        os.mkdir(category_dir_name)
-      except FileExistsError:
-        # It's OK if the directory is already there.
-        pass
+
       # In that directory, create a file or files for the category output as JSON
       output_name = os.path.join(category_dir_name, category + ".json")  # TODO: Change to a list of files
       try:

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -1,7 +1,7 @@
 # Verifier class for checking actual test output vs. expectations
 
 from datetime import datetime, timezone
-
+import glob
 import json
 import os
 import sys
@@ -137,39 +137,61 @@ class Verifier():
                                         self.options.input_path,
                                         verify_file_name)
 
-        # Where the results are, under the exec path.
-        result_path = os.path.join(self.file_base,
+        # All the version directories of the executor results
+
+        results_root = os.path.join(self.file_base,
                                    self.options.output_path,
                                    exec,
-                                   self.testData.testDataFilename)
+                                   '*'
+                                  )
+        version_result_directories = glob.glob(results_root)
 
-        report_path = os.path.join(
-            self.file_base,
-            self.options.report_path,
-            exec,
-            self.testData.testDataFilename)
+        # Create a report plan for each version found for this executor.
+        for result_version_path in version_result_directories:
+          result_version = os.path.basename(result_version_path)
 
-        # Make file.html
-        report_html_path = os.path.join(
-            self.file_base,
-            self.options.report_path,
-            exec,
-            self.testData.testDataFilename + '.html')
+          # Where the results are, under the exec path.
+          result_path = os.path.join(self.file_base,
+                                     self.options.output_path,
+                                     exec,
+                                     result_version,
+                                     self.testData.testDataFilename)
 
-        # The test report to use for verification summary.
-        new_report = TestReport()
-        new_report.report_file_path = report_path
+          report_path = os.path.join(
+              self.file_base,
+              self.options.report_path,
+              exec,
+              result_version,
+              self.testData.testDataFilename)
 
-        new_report.report_html_path = report_html_path
+          # Make file.html
+          report_html_path = os.path.join(
+              self.file_base,
+              self.options.report_path,
+              exec,
+              result_version,
+              self.testData.testDataFilename + '.html')
 
-        # The verify plan for this
-        new_verify_plan = VerifyPlan(
-            testdata_path, result_path, verify_file_path, report_path)
-        new_verify_plan.setTestType(test_type)
-        new_verify_plan.setExec(exec)
-        new_verify_plan.setReport(new_report)
+          # Set the name of the verification file. These files are
+          # usually in the same directory as the test data files.
+          verify_file_path = os.path.join(self.file_base,
+                                          self.options.input_path,
+                                          verify_file_name)
 
-        self.verify_plans.append(new_verify_plan)
+          # The test report to use for verification summary.
+          new_report = TestReport()
+          new_report.report_file_path = report_path
+
+          new_report.report_html_path = report_html_path
+
+          # The verify plan for this
+          new_verify_plan = VerifyPlan(
+              testdata_path, result_path, verify_file_path, report_path, result_version)
+          new_verify_plan.setTestType(test_type)
+          new_verify_plan.setExec(exec)
+          new_verify_plan.setReport(new_report)
+
+          self.verify_plans.append(new_verify_plan)
 
   def verifyDataResults(self):
     # For each pair of files in the test plan, compare with expected
@@ -183,7 +205,6 @@ class Verifier():
 
       self.test_type = vplan.test_type
 
-      print('  Verifying test %s on %s executor' % (self.test_type, self.exec))
       if not self.openVerifyFiles():
         continue
       self.compareTestToExpected()
@@ -400,11 +421,12 @@ class Verifier():
 class VerifyPlan():
 # Details of a verification plan
   def __init__(self,
-               testdata_path, result_path, verify_path, report_path):
+               testdata_path, result_path, verify_path, report_path, report_version):
     self.testdata_path = testdata_path
     self.result_path = result_path
     self.verify_path = verify_path
     self.report_path = report_path
+    self.report_version = report_version
     self.exec = None
     self.test_type = None
 

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -157,20 +157,23 @@ class Verifier():
                                      result_version,
                                      self.testData.testDataFilename)
 
-          report_path = os.path.join(
-              self.file_base,
-              self.options.report_path,
-              exec,
-              result_version,
-              self.testData.testDataFilename)
+          # Where the HTML and JSON reports are created
+          report_directory = os.path.join(
+            self.file_base,
+            self.options.report_path,
+            exec,
+            result_version)
 
-          # Make file.html
+          report_path = os.path.join(report_directory, self.testData.testDataFilename)
+
+          # Make file.html, removing the .json part
+          report_html_name = self.testData.testDataFilename.rpartition('.')[0] + '.html'
           report_html_path = os.path.join(
               self.file_base,
               self.options.report_path,
               exec,
               result_version,
-              self.testData.testDataFilename + '.html')
+              report_html_name)
 
           # Set the name of the verification file. These files are
           # usually in the same directory as the test data files.
@@ -181,12 +184,14 @@ class Verifier():
           # The test report to use for verification summary.
           new_report = TestReport()
           new_report.report_file_path = report_path
+          new_report.report_directory = os.path.dirname(report_path)
 
           new_report.report_html_path = report_html_path
 
           # The verify plan for this
           new_verify_plan = VerifyPlan(
-              testdata_path, result_path, verify_file_path, report_path, result_version)
+              testdata_path, result_path, verify_file_path, report_path, result_version,
+          )
           new_verify_plan.setTestType(test_type)
           new_verify_plan.setExec(exec)
           new_verify_plan.setReport(new_report)
@@ -426,6 +431,7 @@ class VerifyPlan():
     self.result_path = result_path
     self.verify_path = verify_path
     self.report_path = report_path
+    self.report_directory = os.path.dirname(report_path)
     self.report_version = report_version
     self.exec = None
     self.test_type = None

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -138,12 +138,12 @@ class Verifier():
                                         verify_file_name)
 
         # All the version directories of the executor results
-
         results_root = os.path.join(self.file_base,
                                    self.options.output_path,
                                    exec,
                                    '*'
                                   )
+        # All the result directories for this executor.
         version_result_directories = glob.glob(results_root)
 
         # Create a report plan for each version found for this executor.
@@ -151,42 +151,26 @@ class Verifier():
           result_version = os.path.basename(result_version_path)
 
           # Where the results are, under the exec path.
-          result_path = os.path.join(self.file_base,
-                                     self.options.output_path,
-                                     exec,
-                                     result_version,
+          result_path = os.path.join(result_version_path,
                                      self.testData.testDataFilename)
 
           # Where the HTML and JSON reports are created
           report_directory = os.path.join(
             self.file_base,
             self.options.report_path,
-            exec,
-            result_version)
+            exec, result_version, test_type)
 
           report_path = os.path.join(report_directory, self.testData.testDataFilename)
 
           # Make file.html, removing the .json part
           report_html_name = self.testData.testDataFilename.rpartition('.')[0] + '.html'
           report_html_path = os.path.join(
-              self.file_base,
-              self.options.report_path,
-              exec,
-              result_version,
-              report_html_name)
-
-          # Set the name of the verification file. These files are
-          # usually in the same directory as the test data files.
-          verify_file_path = os.path.join(self.file_base,
-                                          self.options.input_path,
-                                          verify_file_name)
+              report_directory, report_html_name)
 
           # The test report to use for verification summary.
-          new_report = TestReport()
-          new_report.report_file_path = report_path
-          new_report.report_directory = os.path.dirname(report_path)
-
-          new_report.report_html_path = report_html_path
+          new_report = TestReport(report_path, report_html_path)
+          # new_report.setExec
+          # new_report.setTestType
 
           # The verify plan for this
           new_verify_plan = VerifyPlan(
@@ -448,8 +432,8 @@ class VerifyPlan():
   def setReport(self, new_report):
     self.report_json = new_report
 
-
 class Tester():
+
   def __init__(self, title=None):
     self.title = title
     self.test_type = None


### PR DESCRIPTION
This updates lots of things, including a start on loading data via JSON fetch. It also restructures the directory structure, creating subdirectories with versions under testResults/node and testResults/rust.

├── node
│   ├── v16.19.1
│   │   ├── coll_shift_short
│   │   │   ├── coll_test_shift.html
│   │   │   ├── coll_test_shift.json
│   │   │   ├── failing_tests
│   │   │   │   └── failing_tests.json
│   │   │   ├── pass
│   │   │   │   └── pass.json
│   │   │   ├── test_errors
│   │   │   │   └── test_errors.json
│   │   │   └── unsupported
│   │   │       └── unsupported.json
│   │   ├── lang_names
│   │   │   ├── failing_tests
│   │   │   │   └── failing_tests.json
│   │   │   ├── lang_name_test_file.html
│   │   │   ├── lang_name_test_file.json
│   │   │   ├── pass
│   │   │   │   └── pass.json
│   │   │   ├── test_errors
│   │   │   │   └── test_errors.json
│   │   │   └── unsupported
│   │   │       └── unsupported.json
│   │   └── number_fmt
...