### PR TITLE
Fix Rust build errors

### DIFF
--- a/executors/rust/Cargo.toml
+++ b/executors/rust/Cargo.toml
@@ -24,3 +24,12 @@ icu_testdata = { version="1.0.0", features = ["metadata"] }
 icu_provider = { version="1.0.0"}
 
 [features]
+
+[profile.icu4x_1_0]
+rust-version = "1.61"
+
+[profile.icu4x_1_1]
+rust-version = "1.61"
+
+[profile.icu4x_1_2]
+rust-version = "1.68.2"

--- a/executors/rust/Cargo.toml
+++ b/executors/rust/Cargo.toml
@@ -24,12 +24,3 @@ icu_testdata = { version="1.0.0", features = ["metadata"] }
 icu_provider = { version="1.0.0"}
 
 [features]
-
-[profile.icu4x_1_0]
-rust-version = "1.61"
-
-[profile.icu4x_1_1]
-rust-version = "1.61"
-
-[profile.icu4x_1_2]
-rust-version = "1.68.2"

--- a/executors/rust/Cargo.toml
+++ b/executors/rust/Cargo.toml
@@ -14,7 +14,7 @@ substring = "1.0"
 json = "0.12.4"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.48"
-rustc_version_runtime = "0.1.61"
+rustc_version_runtime = "0.1.*"
     
 fixed_decimal = {version="0.5.0"}
 writeable =  {version="0.5.0"}

--- a/executors/rust/Cargo.toml
+++ b/executors/rust/Cargo.toml
@@ -14,7 +14,7 @@ substring = "1.0"
 json = "0.12.4"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.48"
-rustc_version_runtime = "0.1.*"
+rustc_version_runtime = "0.1.61"
     
 fixed_decimal = {version="0.5.0"}
 writeable =  {version="0.5.0"}

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -18,7 +18,7 @@ mkdir -p $TEMP_DIR/testData
 # Compile Rust executor code for ICU4X 1.0
 pushd executors/rust/
 cargo clean
-cargo build --release --profile icu4x_1_0
+rustup run 1.61 cargo build --release
 popd
 
 #

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -17,7 +17,7 @@ mkdir -p $TEMP_DIR/testData
 
 # Compile Rust executor code
 pushd executors/rust/
-clean
+cargo clean
 cargo build --release
 popd
 

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -15,10 +15,10 @@ rm -rf $TEMP_DIR
 # Clear out old data, then create new directory and copy test / verify data there
 mkdir -p $TEMP_DIR/testData
 
-# Compile Rust executor code
+# Compile Rust executor code for ICU4X 1.0
 pushd executors/rust/
 cargo clean
-cargo build --release
+cargo build --release --profile icu4x_1_0
 popd
 
 #

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -17,6 +17,7 @@ mkdir -p $TEMP_DIR/testData
 
 # Compile Rust executor code
 pushd executors/rust/
+clean
 cargo build --release
 popd
 

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -18,7 +18,7 @@ mkdir -p $TEMP_DIR/testData
 # Compile Rust executor code for ICU4X 1.0
 pushd executors/rust/
 cargo clean
-rustup install 1.6.1
+rustup install 1.61
 rustup run 1.61 cargo build --release
 popd
 

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -18,6 +18,7 @@ mkdir -p $TEMP_DIR/testData
 # Compile Rust executor code for ICU4X 1.0
 pushd executors/rust/
 cargo clean
+rustup install 1.6.1
 rustup run 1.61 cargo build --release
 popd
 


### PR DESCRIPTION
There seems to be a version ambiguity that is affecting the Rust compilation on CI.

PR #59 is [failing CI](https://github.com/unicode-org/conformance/actions/runs/4942064491/jobs/8835849491) in the Rust build even though it has not updated Rust code.