### PR TITLE
Don't run artifacts build on PRs

### DIFF
--- a/.github/workflows/gcs-upload.yml
+++ b/.github/workflows/gcs-upload.yml
@@ -24,8 +24,6 @@ name: Artifacts Build
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: '*'
 
 
 jobs:


### PR DESCRIPTION
I think GitHub is blocking access to the GCP secret from PRs.