### PR TITLE
Fix ICU data version on summary page

### DIFF
--- a/verifier/detail_template.html
+++ b/verifier/detail_template.html
@@ -560,7 +560,7 @@ table th {
     </details>
 
     <details>
-      <summary>Unsupported Tests errors <span id='unsupported_count'>($unsupported_count)</span></summary>
+      <summary>Unsupported tests<span id='unsupported_count'>($unsupported_count)</span></summary>
       <div id="unsupported-pagination-container"></div>
       <div id="unsupported-data-container"></div>
       <div id='testUnsupportedCharacterized'>

--- a/verifier/summary_template.html
+++ b/verifier/summary_template.html
@@ -93,7 +93,7 @@
                           let link = '<a href="' +
                               report['html_file_name'] + '"' +
                               ' target="_blank">' +
-                              report['version']['icuVersion'] +
+                              report['icu_version'] +
                               '</a><br />';
                           details.push(link);
                       }


### PR DESCRIPTION
This now shows the ICU data version on the summary page, not the ICU version in the executor.

Also, makes a small change on text page for unsupported tests.