### PR TITLE
Fix dart

### DIFF
--- a/executors/dart_web/bin/collator.dart
+++ b/executors/dart_web/bin/collator.dart
@@ -11,7 +11,7 @@ String testCollationShort(String jsonEncoded) {
   var json =
       jsonDecode(jsonEncoded); // For the moment, use strings for easier interop
   // Global default locale
-  var testLocale = '';
+  var testLocale = 'en';
   Map<String, dynamic> outputLine;
 
   // Set up collator object with optional locale and testOptions.

--- a/executors/dart_web/bin/make_runnable_by_node.dart
+++ b/executors/dart_web/bin/make_runnable_by_node.dart
@@ -25,8 +25,10 @@ void setVersionFile() {
 
   var version = lockfile.packages['intl4x']?.version;
   if (version != null) {
-    File('out/version.js').writeAsStringSync(
-        '''const dartVersion = "${version.canonicalizedVersion}";''');
+    File('out/version.js').writeAsStringSync('''
+const dartVersion = "${version.canonicalizedVersion}";
+module.exports = { dartVersion };
+''');
   }
 }
 

--- a/executors/dart_web/bin/make_runnable_by_node.dart
+++ b/executors/dart_web/bin/make_runnable_by_node.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:pubspec_lock_parse/pubspec_lock_parse.dart';
+
 Future<void> main(List<String> args) async {
   var name = 'collatorDart';
   var compile = await Process.run('dart', [
@@ -12,6 +14,20 @@ Future<void> main(List<String> args) async {
   print(compile.stderr);
 
   prepareOutFile(name, ['testCollationShort']);
+
+  setVersionFile();
+}
+
+void setVersionFile() {
+  var lockStr = File('pubspec.lock').readAsStringSync();
+
+  final lockfile = PubspecLock.parse(lockStr);
+
+  var version = lockfile.packages['intl4x']?.version;
+  if (version != null) {
+    File('out/version.js').writeAsStringSync(
+        '''const dartVersion = "${version.canonicalizedVersion}";''');
+  }
 }
 
 /// Prepare the file to export `testCollationShort`

--- a/executors/dart_web/out/executor.js
+++ b/executors/dart_web/out/executor.js
@@ -120,9 +120,10 @@ rl.on('line', function (line) {
   if (line == "#VERSION") {
     // JSON output of the test enviroment.
     let versionJson = {
-      'platform': 'NodeJS',
+      'platform': 'Dart Web',
       'platformVersion': process.version,
       'icuVersion': process.versions.icu,
+      'intlVersion': dartVersion,
     };
 
     // TODO: Make this more specific JSON info.

--- a/executors/dart_web/out/executor.js
+++ b/executors/dart_web/out/executor.js
@@ -17,6 +17,7 @@
 
 
 let collator = require('./collator.js')
+const { dartVersion } = require('./version.js')
 
 /**
  * TODOs:

--- a/executors/dart_web/out/version.js
+++ b/executors/dart_web/out/version.js
@@ -1,1 +1,2 @@
 const dartVersion = "0.4.0";
+module.exports = { dartVersion };

--- a/executors/dart_web/out/version.js
+++ b/executors/dart_web/out/version.js
@@ -1,0 +1,1 @@
+const dartVersion = "0.4.0";

--- a/executors/dart_web/pubspec.yaml
+++ b/executors/dart_web/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   intl4x: ^0.4.0
+  pubspec_lock_parse: ^2.2.0
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
- Add version string of the `intl4x` dependency by parsing the `pubspec.lock` file
- Add locale to avoid having `dart_web` looking for the users locale in the `window` object, which doesn't exist in NodeJS.