### PR TITLE
Adding coll_nonignorable_short testing

### DIFF
--- a/executors/node/collator_nonignorable.js
+++ b/executors/node/collator_nonignorable.js
@@ -1,0 +1,44 @@
+// The Collator for nonignorable short tests.
+
+// !!! TODO: Collation: determine the sensitivity that corresponds
+// to the strength.
+module.exports = {
+
+  testCollationNonignorableShort: function(json) {
+
+    // Global default locale
+    let testLocale = '';
+    let testCollOptions = {};
+
+    // Set up collator object with optional locale and testOptions.
+    let coll;
+    try {
+      if (testLocale) {
+        coll = new Intl.Collator(testLocale, testCollOptions);
+      } else {
+        coll = new Intl.Collator(testCollOptions);
+      }
+      let d1 = json['string1'];
+      let d2 = json['string2'];
+
+      const compared = coll.compare(d1, d2);
+      let result = compared<= 0 ? true : false;
+      let resultString = result ? true : false;
+      outputLine = {'label':json['label'],
+                    "result": result
+                   }
+
+      if (result != true) {
+        // Additional info for the comparison
+        outputLine['compare'] = compared;
+      }
+
+    } catch (error) {
+      outputLine =  {'label': json['label'],
+                     'error_message': error.message,
+                     'error': 'Collator compare failed'
+                 };
+    }
+    return outputLine;
+  }
+};

--- a/executors/node/executor.js
+++ b/executors/node/executor.js
@@ -18,6 +18,8 @@
 
 let collator = require('./collator.js')
 
+let collator_nonignorable = require('./collator_nonignorable.js')
+
 let numberformatter = require('./numberformat.js')
 
 let displaynames = require('./displaynames.js')
@@ -44,6 +46,7 @@ let doLogOutput = 0;
 // Test type support. Add new items as they are implemented
 const testTypes = {
   TestCollShiftShort : Symbol("coll_shift_short"),
+  TestCollNonignorableShort : Symbol("coll_nonignorable_short"),
   TestDecimalFormat : Symbol("decimal_fmt"),
   TestNumberFormat : Symbol("number_fmt"),
   TestDateTimeFormat : Symbol("datetime_fmtl"),
@@ -55,6 +58,7 @@ const testTypes = {
 
 const supported_test_types = [
   Symbol("coll_shift_short"),
+  Symbol("coll_nonignorable_short"),
   Symbol("decimal_fmt"),
   Symbol("number_fmt"),
   Symbol("display_names"),
@@ -63,6 +67,7 @@ const supported_test_types = [
 const supported_tests_json = {"supported_tests":
                               [
                                 "coll_shift_short",
+                                "coll_nonignorable_short",
                                 "decimal_fmt",
                                 "number_fmt",
                                 "display_names",
@@ -90,6 +95,11 @@ function parseJsonForTestId(parsed) {
   if (testId == "coll_shift_short") {
     return testTypes.TestCollShiftShort;
   }
+
+  if (testId == "coll_nonignorable_short"){
+    return testTypes.TestCollNonignorableShort;
+  }
+
   if (testId == "decimal_fmt" || testId == "number_fmt") {
     return testTypes.TestDecimalFormat;
   }
@@ -168,6 +178,9 @@ rl.on('line', function(line) {
     const test_type = parsedJson["test_type"];
     if (test_type == "coll_shift_short") {
       outputLine = collator.testCollationShort(parsedJson);
+    } else
+    if (test_type == "coll_nonignorable_short") {
+      outputLine = collator_nonignorable.testCollationNonignorableShort(parsedJson);
     } else
     if (test_type == "decimal_fmt" || test_type == "number_fmt") {
       outputLine = numberformatter.testDecimalFormat(parsedJson, doLogInput);

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -69,24 +69,24 @@ echo $?
 #ICU73
 nvm install 20.1.0
 nvm use 20.1.0
-python3 testdriver.py --icu_version icu73 --exec node --test_type coll_shift_short number_fmt lang_names --file_base ../$TEMP_DIR --per_execution 10000
+python3 testdriver.py --icu_version icu73 --exec node --test_type coll_shift_short coll_nonignorable_short number_fmt lang_names --file_base ../$TEMP_DIR --per_execution 10000
 echo $?
 
 #ICU72
 nvm install 18.14.2
 nvm use 18.14.2
-python3 testdriver.py  --icu_version icu72 --exec node --test_type coll_shift_short number_fmt lang_names --file_base ../$TEMP_DIR --per_execution 10000
+python3 testdriver.py  --icu_version icu72 --exec node --test_type coll_shift_short coll_nonignorable_short number_fmt lang_names --file_base ../$TEMP_DIR --per_execution 10000
 echo $?
 
 #ICU71
 nvm install 18.7.0
-python3 testdriver.py --icu_version icu71 --exec node --test_type coll_shift_short number_fmt --file_base ../$TEMP_DIR --per_execution 10000
+python3 testdriver.py --icu_version icu71 --exec node --test_type coll_shift_short coll_nonignorable_short number_fmt --file_base ../$TEMP_DIR --per_execution 10000
 echo $?
 
 # ICU70
 nvm install 14.21.3
 nvm use 14.21.3
-python3 testdriver.py --icu_version icu70 --exec node --test_type coll_shift_short number_fmt --file_base ../$TEMP_DIR --per_execution 10000
+python3 testdriver.py --icu_version icu70 --exec node --test_type coll_shift_short coll_nonignorable_short number_fmt  --file_base ../$TEMP_DIR --per_execution 10000
 echo $?
 
 # ICU69
@@ -96,9 +96,9 @@ python3 testdriver.py --icu_version icu69 --exec node --test_type coll_shift_sho
 echo $?
 
 # ICU4X testing
-python3 testdriver.py --icu_version icu71 --exec rust --test_type coll_shift_short number_fmt lang_names --file_base ../$TEMP_DIR --per_execution 10000
+python3 testdriver.py --icu_version icu71 --exec rust --test_type coll_shift_short coll_nonignorable_short number_fmt lang_names --file_base ../$TEMP_DIR --per_execution 10000
 
-python3 testdriver.py --icu_version icu73 --exec rust --test_type coll_shift_short number_fmt lang_names --file_base ../$TEMP_DIR --per_execution 10000
+python3 testdriver.py --icu_version icu73 --exec rust --test_type coll_shift_short coll_nonignorable_short number_fmt lang_names --file_base ../$TEMP_DIR --per_execution 10000
 echo $?
 
 # Done with test execution
@@ -111,7 +111,7 @@ popd
 # Verify everything
 mkdir -p $TEMP_DIR/testReports
 pushd verifier
-python3 verifier.py --file_base ../$TEMP_DIR --exec rust node dart_web --test_type coll_shift_short number_fmt lang_names 
+python3 verifier.py --file_base ../$TEMP_DIR --exec rust node dart_web --test_type coll_shift_short coll_nonignorable_short number_fmt lang_names 
 
 #python3 verifier.py --file_base ../$TEMP_DIR --exec dart_web --test_type coll_shift_short
 #python3 verifier.py --file_base ../$TEMP_DIR --exec cpp--test_type coll_shift_short number_fmt lang_names 

--- a/testdriver/datasets.py
+++ b/testdriver/datasets.py
@@ -88,6 +88,7 @@ cldr_icu_map = {
 # TODO: Can this be added to a configuration file?
 class testType(Enum):
   coll_shift = 'coll_shift_short'
+  coll_nonignorable_short = 'coll_nonignorable_short'
   decimal_fmt = 'decimal_fmt'
   datetime_fmt = 'datetime_fmt'
   display_names = 'display_names'
@@ -107,6 +108,11 @@ testDatasets[testName] = DataSet(testType.coll_shift.value,
                                  'coll_verify_shift.json',
                                  CLDRVersion.CLDR41, ICUVersion.ICU71)
 
+testName = 'coll_nonignorable_short'
+testDatasets[testName] = DataSet(testType.coll_shift.value,
+                                 'coll_nonignorable_short_test.json',
+                                 'coll_nonignorable_short_verify.json',
+                                 CLDRVersion.CLDR43, ICUVersion.ICU73)
 testName = 'coll_shift_67'
 testDatasets[testName] = DataSet(testType.coll_shift.value,
                                  'coll_test0816_U67.json',

--- a/testdriver/ddtargs.py
+++ b/testdriver/ddtargs.py
@@ -31,7 +31,7 @@ class DdtOptions():
     self.parallel_mode = None  # For each exec or using N CPUs?
     self.exec_mode = 'one_test'  # Default. 'multi_test
 
-type_options = ['coll_shift_short', 'decimal_fmt', 'display_names',
+type_options = ['coll_shift_short', 'coll_nonignorable_short', 'decimal_fmt', 'display_names',
                 'number_fmt', 'lang_names', 'ALL']
 
 class DdtArgs():

--- a/testgen/testdata_gen.py
+++ b/testgen/testdata_gen.py
@@ -30,7 +30,7 @@ class generateData():
     def saveJsonFile(self, filename, data, indent=None):
       output_path = os.path.join(self.icu_version, filename)
       output_file = open(output_path, 'w')
-      json.dump(data, output_file, indent=1)
+      json.dump(data, output_file, indent=indent)
       output_file.close()
 
 
@@ -82,6 +82,34 @@ class generateData():
       # And write the files
       self.saveJsonFile('coll_test_shift.json', json_test)
       self.saveJsonFile('coll_verify_shift.json', json_verify)
+
+      return True
+
+    def processNonIgnorableCollationTestData(self):
+      # Alternate set of data to COLL_SHIFT_SHORT.
+      filename = 'CollationTest_NON_IGNORABLE_SHORT.txt'
+
+      # Read raw data
+
+      rawcolltestdata = readFile(filename, self.icu_version)
+
+      if not rawcolltestdata:
+          return None
+
+      test_list = rawcolltestdata.splitlines()
+      # test_list = rawcolltestdata.splitlines()  #OLD
+
+      # Get lists of tests and verify info
+      testdata_object_list, verify_list = generateCollTestDataObjects(test_list)
+      json_test = {}
+      json_verify = {}
+      insert_nonignorable_coll_descr(json_test, json_verify)
+      json_verify['verifications'] = verify_list
+      json_test['tests'] = testdata_object_list
+
+      # And write the files
+      self.saveJsonFile('coll_nonignorable_short_test.json', json_test)
+      self.saveJsonFile('coll_nonignorable_short_verify.json', json_verify)
 
       return True
 
@@ -514,6 +542,10 @@ def insert_coll_descr(tests_obj, verify_obj):
   tests_obj['description'] =  'UCA conformance test. Compare the first data string with the second and with strength = identical level (using S3.10). If the second string is greater than the first string, then stop with an error.'
   return
 
+def insert_nonignorable_coll_descr(tests_obj, verify_obj):
+  verify_obj['Test Scenario'] = tests_obj['Test scenario'] = "coll_nonignorable_short"
+  tests_obj['description'] =  'UCA conformance test. Compare the first data string with the second and with strength = identical level (using S3.10). If the second string is greater than the first string, then stop with an error.'
+  return
 
 def languageNameDescr(tests_json, verify_json):
   # Adds information to LanguageName tests and verify JSON
@@ -570,6 +602,8 @@ def main(args):
                      icu_version)
 
         data_generator.processCollationTestData()
+
+        data_generator.processNonIgnorableCollationTestData()
 
         data_generator.processNumberFmtTestData()
         data_generator.processLangNameTestData()


### PR DESCRIPTION
This adds collation for node, comparing with default parameters. There are still test failures that need to be explained.

And rust doesn't yet implement this option. Note that this could be redone using a runtime parameter to the collation executor rather than separate collation .js code.