### PR TITLE
Replace `python` with `python3`

### DIFF
--- a/genData100.sh
+++ b/genData100.sh
@@ -37,9 +37,9 @@ popd
 
 # Verify that schema files are valid
 pushd schema
-python check_schemas.py $pwd
+python3 check_schemas.py $pwd
 # And check generated data against schemas.
-python check_generated_data.py ../$TEMP_DIR/testData
+python3 check_generated_data.py ../$TEMP_DIR/testData
 popd
 
 all_execs_json=$(jq '.[].run.exec' $source_file | jq -s '.' | jq 'unique')
@@ -103,7 +103,7 @@ popd
 
 # Verify that test output matches schema.
 pushd schema
-python check_test_output.py ../$TEMP_DIR/testOutput
+python3 check_test_output.py ../$TEMP_DIR/testOutput
 popd
 
 # Verify everything

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -36,9 +36,9 @@ popd
 
 # Verify that schema files are valid
 pushd schema
-python check_schemas.py $pwd
+python3 check_schemas.py $pwd
 # And check generated data against schemas.
-python check_generated_data.py ../$TEMP_DIR/testData
+python3 check_generated_data.py ../$TEMP_DIR/testData
 popd
 
 all_execs_json=$(jq '.[].run.exec' $source_file | jq -s '.' | jq 'unique')
@@ -102,7 +102,7 @@ popd
 
 # Verify that test output matches schema.
 pushd schema
-python check_test_output.py ../$TEMP_DIR/testOutput
+python3 check_test_output.py ../$TEMP_DIR/testOutput
 popd
 
 # Verify everything

--- a/testdriver/ddtargs.py
+++ b/testdriver/ddtargs.py
@@ -155,7 +155,7 @@ def argsTestData():
       ['--exec', 'node'],
       ['--exec node rust /bin/mytest'],
       '--exec node --test_type decimal_fmt --icu 71 --cldr 40'.split(),
-      ['--exec', 'python py/exec.py'],
+      ['--exec', 'python3 py/exec.py'],
       '--test_random 1234'.split(),
       ['--exec', '--custom_testfile', 'testData/customtest1.json',
        'testData/customtest2.json',

--- a/testdriver/runCollNum_ALL.sh
+++ b/testdriver/runCollNum_ALL.sh
@@ -1,3 +1,3 @@
 # Runs collation test on only on all executors
 # Test data and output directories are under ~/DDT_DATA
-python3 testdriver.py --test coll_shift_short number_fmt --exec node rust "python ../executors/python/executor.py" --run_limit 27 --file_base ~/DDT_DATA
+python3 testdriver.py --test coll_shift_short number_fmt --exec node rust "python3 ../executors/python/executor.py" --run_limit 27 --file_base ~/DDT_DATA

--- a/testdriver/runColl_ALL.sh
+++ b/testdriver/runColl_ALL.sh
@@ -1,3 +1,3 @@
 # Runs collation test on node, rust, and python
 # Test data and output directories are under ~/DDT_DATA
-python3 testdriver.py --test coll_shift_short --exec node rust "python ../executors/python/executor.py" --run_limit 27 --file_base ~/DDT_DATA
+python3 testdriver.py --test coll_shift_short --exec node rust "python3 ../executors/python/executor.py" --run_limit 27 --file_base ~/DDT_DATA

--- a/testdriver/runColl_python.sh
+++ b/testdriver/runColl_python.sh
@@ -1,3 +1,3 @@
 # Runs collation test on only on python sample
 # Test data and output directories are under ~/DDT_DATA
-python3 testdriver.py --test coll_shift_short --exec "python ../executors/python/executor.py"  --run_limit 3 --file_base ~/DDT_DATA
+python3 testdriver.py --test coll_shift_short --exec "python3 ../executors/python/executor.py"  --run_limit 3 --file_base ~/DDT_DATA

--- a/testdriver/runNum_python.sh
+++ b/testdriver/runNum_python.sh
@@ -1,3 +1,3 @@
 # Runs collation test on only on python sample
 # Test data and output directories are under ~/DDT_DATA
-python3 testdriver.py --test number_fmt --exec "python ../executors/python/executor.py"  --run_limit 3 --file_base ~/DDT_DATA
+python3 testdriver.py --test number_fmt --exec "python3 ../executors/python/executor.py"  --run_limit 3 --file_base ~/DDT_DATA


### PR DESCRIPTION
...according to the common wisdom that it is preferable to explicitly use `python3` when invoking Python 3, rather than just `python`.