### PR TITLE
Add logging configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ testdriver/.local-chrome/
 testgen/*.json
 
 TEMP_DATA/*
+
+debug.log*

--- a/logging.conf
+++ b/logging.conf
@@ -1,0 +1,33 @@
+[loggers]
+keys=root
+
+[logger_root]
+handlers=screen,file
+level=NOTSET
+
+[formatters]
+keys=simple,complex
+
+[formatter_simple]
+format=[%(asctime)s] [%(levelname)s]  %(message)s
+
+[formatter_complex]
+format=[%(asctime)s,%(module)s:%(lineno)d] [%(levelname)s]  %(message)s
+
+[handlers]
+keys=file,screen
+
+[handler_file]
+class=handlers.TimedRotatingFileHandler
+interval=midnight
+backupCount=5
+formatter=complex
+level=DEBUG
+# equivalent to:  'debug.log', when='S', interval=10, backupCount=5
+args=('debug.log', 'S', 10, 5)
+
+[handler_screen]
+class=StreamHandler
+formatter=simple
+level=INFO
+args=(sys.stdout,)

--- a/schema/check_generated_data.py
+++ b/schema/check_generated_data.py
@@ -7,6 +7,7 @@ import json
 
 
 import logging
+import logging.config
 import os.path
 import sys
 
@@ -16,6 +17,8 @@ from schema_files import SCHEMA_FILE_MAP
 from schema_files import ALL_TEST_TYPES
 
 def main(args):
+    logging.config.fileConfig("../logging.conf")
+
     if len(args) <= 1:
         logging.error('Please specify the path to test data directory')
         return

--- a/schema/check_schemas.py
+++ b/schema/check_schemas.py
@@ -7,6 +7,7 @@ import json
 
 
 import logging
+import logging.config
 import os.path
 import sys
 
@@ -16,6 +17,7 @@ from schema_files import ALL_TEST_TYPES
 class ValidateSchema():
     def __init__(self, schema_base='.'):
         self.schema_base = schema_base
+        logging.config.fileConfig("../logging.conf")
 
     def save_schema_validation_summary(self, validation_status):
 

--- a/schema/check_test_output.py
+++ b/schema/check_test_output.py
@@ -8,6 +8,7 @@ import json
 
 
 import logging
+import logging.config
 import os.path
 import sys
 
@@ -17,6 +18,8 @@ from schema_files import SCHEMA_FILE_MAP
 from schema_files import ALL_TEST_TYPES
 
 def main(args):
+    logging.config.fileConfig("../logging.conf")
+
     if len(args) <= 1:
         logging.error('Please specify the path to the test output directory')
         exit(1)

--- a/schema/schema_validator.py
+++ b/schema/schema_validator.py
@@ -10,6 +10,7 @@ from jsonschema import ValidationError
 from jsonschema import exceptions
 
 import logging
+import logging.config
 import os.path
 import sys
 
@@ -32,6 +33,8 @@ class ConformanceSchemaValidator():
         self.executors = []
         self.icu_versions = []
         self.debug_leve = 0
+
+        logging.config.fileConfig("../logging.conf")
 
     def validate_json_file(self, schema_file_path, data_file_path):
         # Returns  True, None if data is validated against the schema
@@ -139,7 +142,7 @@ class ConformanceSchemaValidator():
             test_result = result
         results['result'] = result
         if result:
-            logging.info('Test data %s validated with %s, ICU %s', test_type, icu_version)
+            logging.info('Test data %s validated successfully, with ICU %s', test_type, icu_version)
         else:
             logging.error('Test data %s FAILED with ICU %s: %s', test_type, icu_version, err_info)
 

--- a/testdriver/testdriver.py
+++ b/testdriver/testdriver.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 import json
 import logging
+import logging.config
 import os
 import subprocess
 import sys
@@ -24,6 +25,9 @@ class TestDriver:
         self.icuVersion = None
         self.test_plans = []
         self.debug = False
+
+        logging.config.fileConfig("../logging.conf")
+
         return
 
     def set_args(self, arg_options):

--- a/testdriver/testplan.py
+++ b/testdriver/testplan.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import glob
 import json
 import logging
+import logging.config
 import os
 import subprocess
 import sys
@@ -52,6 +53,8 @@ class TestPlan:
         self.progress_interval = 1000
 
         self.verifier = None
+
+        logging.config.fileConfig("../logging.conf")
 
     def set_options(self, options):
         self.options = options

--- a/testgen/testdata_gen.py
+++ b/testgen/testdata_gen.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import logging
+import logging.config
 import math
 import os
 import re
@@ -25,6 +26,8 @@ class generateData():
         self.icu_version = icu_version
         # If set, this is the maximum number of tests generated for each.
         self.run_limit = None
+
+        logging.config.fileConfig("../logging.conf")
 
     def setVersion(self, selected_version):
         self.icu_version = selected_version

--- a/verifier/report_template.py
+++ b/verifier/report_template.py
@@ -2,11 +2,14 @@
 import glob
 import json
 import logging
+import logging.config
 from string import Template
 import sys
 
 class reportTemplate():
     def __init__(self):
+        logging.config.fileConfig("../logging.conf")
+
         # Read the template data
         detail_template = ''
         filename = 'detail_template.html'

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -13,6 +13,7 @@ from datetime import datetime
 import glob
 import json
 import logging
+import logging.config
 import os
 from string import Template
 import sys
@@ -45,6 +46,8 @@ class DiffSummary:
         self.single_diff_count = 0
 
         self.params_diff = {}
+
+        logging.config.fileConfig("../logging.conf")
 
     def add_diff(self, num_diffs, diff_list, last_diff):
         # Record single character differences
@@ -126,6 +129,8 @@ class TestReport:
         self.test_error_detail_template = templates.test_error_detail_template
 
         self.test_unsupported_template = templates.test_unsupported_template
+
+        logging.config.fileConfig("../logging.conf")
 
     def set_title(self, executor, result_version, test_type):
         self.title = 'Test %s executed on %s with data %s' % (test_type, executor, result_version)
@@ -862,6 +867,8 @@ class SummaryReport:
         self.entry_template = Template(
             '<td>$report_detail</td>'
         )
+
+        logging.config.fileConfig("../logging.conf")
 
     def get_json_files(self):
         # For each executor directory in testReports,

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -4,6 +4,7 @@ import datetime
 import glob
 import json
 import logging
+import logging.config
 import os
 import shutil
 import sys
@@ -61,6 +62,8 @@ class Verifier:
 
         # Filename used for the json version of verifier output
         self.report_filename = VERIFIER_REPORT_NAME
+
+        logging.config.fileConfig("../logging.conf")
 
     def open_verify_files(self):
         # Get test data, verify data, and results for a case.


### PR DESCRIPTION
Formats logging output so that it simultaneously saves to a file and prints to the console.  The console looks like:

```
...
[2023-11-17 16:04:59,343] [WARNING]  VALIDATION WORKS: collation_short icu69
[2023-11-17 16:04:59,343] [INFO]  Checking collation_short, icu70
[2023-11-17 16:04:59,343] [INFO]  Validating collation_short with icu version icu70
[2023-11-17 16:05:12,297] [INFO]  This test output file validates: ../TEMP_DATA/testData/icu70/collation_test.json, ./collation_short/test_schema.json:
[2023-11-17 16:05:12,371] [INFO]  Test data collation_short validated successfully, with ICU icu70
{'test_type': 'collation_short', 'icu_version': 'icu70', 'result': True, 'err_info': None, 'test_schema': './collation_short/test_schema.json', 'data_file_name': '../TEMP_DATA/testData/icu70/collation_test.json'}
...
```

while the file will have the module and line number and extra levels of details in the logging, like:

```
...
2023-11-17 16:06:20,930,schema_validator:74] [INFO]  This test output file validates: ../TEMP_DATA/testData/icu73/lang_name_test_file.json, ./language_names/test_schema.json:
[2023-11-17 16:06:20,977,schema_validator:145] [INFO]  Test data language_names validated successfully, with ICU icu73
[2023-11-17 16:06:20,977,schema_validator:108] [WARNING]  VALIDATION WORKS: language_names icu73
[2023-11-17 16:06:20,977,schema_validator:96] [DEBUG]  Checking test data language_names, icu74
[2023-11-17 16:06:20,977,schema_validator:97] [INFO]  Checking language_names, icu74
[2023-11-17 16:06:20,978,schema_validator:114] [INFO]  Validating language_names with icu version icu74
...
```