### PR TITLE
Add ICU4J executor skeleton implementation

### DIFF
--- a/executors/icu4j/73/executor-icu4j/pom.xml
+++ b/executors/icu4j/73/executor-icu4j/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.unicode.conformance</groupId>
+  <artifactId>executor-icu4j</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>executor-icu4j</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+
+        <!-- JSON library -->
+        <plugin>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+          <version>2.10.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/executors/icu4j/73/executor-icu4j/src/main/java/org/unicode/conformance/Icu4jExecutor.java
+++ b/executors/icu4j/73/executor-icu4j/src/main/java/org/unicode/conformance/Icu4jExecutor.java
@@ -1,0 +1,13 @@
+package org.unicode.conformance;
+
+/**
+ * Hello world!
+ *
+ */
+public class Icu4jExecutor 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/executors/icu4j/73/executor-icu4j/src/test/java/org/unicode/conformance/Icu4jExecutorTest.java
+++ b/executors/icu4j/73/executor-icu4j/src/test/java/org/unicode/conformance/Icu4jExecutorTest.java
@@ -1,0 +1,20 @@
+package org.unicode.conformance;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class Icu4jExecutorTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -89,7 +89,8 @@ jq -c '.[]' ../$source_file | while read i; do
     exec_command=$(jq -r -c '.run.exec' <<< $i)
     test_type=$(jq -r -c '.run.test_type | join(" ")'  <<< $i)
     per_execution=$(jq -r -c '.run.per_execution' <<< $i)
-    python3 testdriver.py --icu_version $icu_version --exec $exec_command --test_type $test_type --file_base ../$TEMP_DIR --per_execution $per_execution
+    ignore=$(jq -r -c '.run.ignore' <<< $i)
+    python3 testdriver.py --icu_version $icu_version --exec $exec_command --test_type $test_type --file_base ../$TEMP_DIR --per_execution $per_execution --ignore $ignore
     echo $?
 done
 

--- a/run_config.json
+++ b/run_config.json
@@ -153,5 +153,16 @@
       ],
       "per_execution": 10000
     }
-  }  
+  },
+  {
+    "run": {
+      "icu_version": "icu73",
+      "exec": "icu4j",
+      "test_type": [
+        "collation_short"
+      ],
+      "per_execution": 10000,
+      "ignore": true
+    }
+  }
 ]

--- a/testdriver/ddtargs.py
+++ b/testdriver/ddtargs.py
@@ -140,6 +140,8 @@ def setCommonArgs(parser):
 
   parser.add_argument('--debug_level', default=None)
 
+  parser.add_argument('--ignore', default=None)
+
 def argsTestData():
   tests = [
       ['--test_type', 'collation_short'],

--- a/testdriver/testdriver.py
+++ b/testdriver/testdriver.py
@@ -60,6 +60,7 @@ class TestDriver:
                         exec_command = ddt_data.allExecutors.versionForCldr(
                             executor, resolved_cldr_version)
                         # The command needs to be something else!
+
                     new_plan = TestPlan(exec_command, test_type)
                     new_plan.set_options(arg_options)
                     new_plan.test_lang = executor.split()[0]
@@ -70,7 +71,8 @@ class TestDriver:
                     except KeyError as err:
                         logging.warning('!!! %s: No test data filename for %s', err, test_type)
 
-                    self.test_plans.append(new_plan)
+                    if not new_plan.ignore:
+                        self.test_plans.append(new_plan)
 
     def parse_args(self, args):
         # TODO: handle arguments for:

--- a/testdriver/testdriver.py
+++ b/testdriver/testdriver.py
@@ -52,8 +52,7 @@ class TestDriver:
                         # Run a non-specified executor. Compatibility of versions
                         # between test data and the executor should be done the text executor
                         # program itself.
-                        if self.debug:
-                            logging.info('!!! **** CUSTOM EXEC = %s', executor)
+                        logging.error('No executable command configured for executor platform: %s', executor)
                         exec_command = {'path': executor}
                     else:
                         # Set details for execution from ExecutorInfo

--- a/testdriver/testplan.py
+++ b/testdriver/testplan.py
@@ -35,6 +35,9 @@ class TestPlan:
         self.options = None
         self.testData = None
 
+        # Ignore this TestPlan. In other words, do not run
+        self.ignore = None
+
         # Additional args to subprocess.run
         self.args = args
 
@@ -62,6 +65,9 @@ class TestPlan:
             self.icu_version = options.icu_version
         except KeyError:
             logging.warning('NO ICU VERSION SET')
+
+        if options.ignore:
+            self.ignore = True
 
     def set_test_data(self, test_data):
         self.testData = test_data  # ???['tests']

--- a/testdriver/testplan.py
+++ b/testdriver/testplan.py
@@ -66,7 +66,7 @@ class TestPlan:
         except KeyError:
             logging.warning('NO ICU VERSION SET')
 
-        if options.ignore:
+        if options.ignore and not options.ignore == "null":
             self.ignore = True
 
     def set_test_data(self, test_data):


### PR DESCRIPTION
Add an empty implementation for an ICU4J executor.  Also, add an option to running an executor (called `--ignore`) that allows a new executor instance to be skipped.