### PR TITLE
Reduce standard output printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,6 @@ testgen/*.json
 
 TEMP_DATA/*
 
+# log files (including logrotate state and file backups)
 debug.log*
+logrotate.state

--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ Requirements to run Data Driven Testing code locally:
         ```
         rustup update
         ```
+  - Install `logrotate`
+      ```
+      sudo apt-get install logrotate
+      ```
 
 # History
 

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -140,3 +140,6 @@ echo "End-to-end script finished successfully"
 # Clean up directory
 # ... after results are reported
 #rm -rf ../$TEMP_DIR
+
+# Rotate log files
+logrotate -s logrotate.state logrotate.conf

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -5,13 +5,13 @@
 # Save the results
 set -e
 
+##########
+# Setup (generate) test data & expected values
+##########
+
 # Enable seting the version of NodeJS
 export NVM_DIR=$HOME/.nvm;
 source $NVM_DIR/nvm.sh;
-
-#
-# Setup
-#
 
 export TEMP_DIR=TEMP_DATA
 rm -rf $TEMP_DIR
@@ -19,14 +19,9 @@ rm -rf $TEMP_DIR
 # Clear out old data, then create new directory and copy test / verify data there
 mkdir -p $TEMP_DIR/testData
 
-#
-# Setup (generate) test data & expected values
-# 
-
-source_file=${1:-'run_config.json'}
-
 
 # Generates all new test data
+source_file=${1:-'run_config.json'}
 pushd testgen
 all_icu_versions=$(jq '.[].run.icu_version' ../$source_file | jq -s '.' | jq 'unique' | jq -r 'join(" ")')
 python3 testdata_gen.py  --icu_versions $all_icu_versions
@@ -41,7 +36,10 @@ python3 check_schemas.py $pwd
 python3 check_generated_data.py ../$TEMP_DIR/testData
 popd
 
-all_execs_json=$(jq '.[].run.exec' $source_file | jq -s '.' | jq 'unique')
+##########
+# Run tests using per-platform executors
+##########
+
 #
 # Run test data tests through all executors
 #
@@ -53,6 +51,15 @@ all_execs_json=$(jq '.[].run.exec' $source_file | jq -s '.' | jq 'unique')
 #     cargo build --release
 #     popd
 # fi
+
+#
+# Run Dart executors in a custom way
+#
+
+# TODO(?): Figure out why datasets.py can't support runnign multiple CLI commands,
+# if that is the reason why Dart needs custom handling in this end-to-end script
+
+all_execs_json=$(jq '.[].run.exec' $source_file | jq -s '.' | jq 'unique')
 
 if jq -e 'index("dart_native")' <<< $all_execs_json > /dev/null
 then
@@ -73,12 +80,17 @@ fi
 # Executes all tests on that new data in the new directory
 mkdir -p $TEMP_DIR/testOutput
 
+#
 # Invoke all tests on all platforms
+#
+
+# Change to directory of `testdriver` (which will be used to invoke each platform executor)
 pushd testdriver
 
 # Set to use NVM
 source "$HOME/.nvm/nvm.sh"
 
+# Invoke all tests
 jq -c '.[]' ../$source_file | while read i; do
     if jq -e 'has("prereq")' <<< $i > /dev/null
     then
@@ -97,9 +109,9 @@ done
 # Done with test execution
 popd
 
-#
+##########
 # Run verifier
-#
+##########
 
 # Verify that test output matches schema.
 pushd schema
@@ -115,6 +127,10 @@ all_execs=$(jq -r 'join(" ")' <<< $all_execs_json)
 python3 verifier.py --file_base ../$TEMP_DIR --exec $all_execs --test_type $all_test_types
 
 popd
+
+##########
+# Finish and clean up
+##########
 
 #
 # Push testresults and test reports to Cloud Storge

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -5,6 +5,9 @@
 # Save the results
 set -e
 
+# Rotate log files
+logrotate -s logrotate.state logrotate.conf
+
 ##########
 # Setup (generate) test data & expected values
 ##########
@@ -140,6 +143,3 @@ echo "End-to-end script finished successfully"
 # Clean up directory
 # ... after results are reported
 #rm -rf ../$TEMP_DIR
-
-# Rotate log files
-logrotate -s logrotate.state logrotate.conf

--- a/logging.conf
+++ b/logging.conf
@@ -18,13 +18,10 @@ format=[%(asctime)s,%(module)s:%(lineno)d] [%(levelname)s]  %(message)s
 keys=file,screen
 
 [handler_file]
-class=handlers.TimedRotatingFileHandler
-interval=midnight
-backupCount=5
+class=handlers.RotatingFileHandler
 formatter=complex
 level=DEBUG
-# equivalent to:  'debug.log', when='S', interval=10, backupCount=5
-args=('debug.log', 'S', 10, 5)
+args=('debug.log', 'a')
 
 [handler_screen]
 class=StreamHandler

--- a/logrotate.conf
+++ b/logrotate.conf
@@ -1,0 +1,15 @@
+"testdriver/debug.log" {
+    rotate 3
+}
+
+"verifier/debug.log" {
+    rotate 3
+}
+
+"schema/debug.log" {
+    rotate 3
+}
+
+"testgen/debug.log" {
+    rotate 3
+}

--- a/schema/check_generated_data.py
+++ b/schema/check_generated_data.py
@@ -25,7 +25,7 @@ def main(args):
     else:
         test_data_path = args[1]
 
-    print('TEST DATA PATH = %s' % test_data_path)
+    logging.debug('TEST DATA PATH = %s', test_data_path)
 
     logger = logging.Logger("Checking Test Data vs. Schemas LOGGER")
     logger.setLevel(logging.INFO)
@@ -37,12 +37,12 @@ def main(args):
     if os.path.exists(test_data_path):
         check_path = os.path.join(test_data_path, 'icu*')
         icu_dirs = glob.glob(check_path)
-        print('ICU DIRECTORIES = %s' % icu_dirs)
+        logging.debug('ICU DIRECTORIES = %s', icu_dirs)
         for dir in icu_dirs:
             icu_versions.append(os.path.basename(dir))
 
-    print('ICU directories = %s' % icu_versions)
-    print('test types = %s' % ALL_TEST_TYPES)
+    logging.debug('ICU directories = %s', icu_versions)
+    logging.debug('test types = %s', ALL_TEST_TYPES)
 
     validator = schema_validator.ConformanceSchemaValidator()
     # Todo: use setters to initialize validator
@@ -56,7 +56,7 @@ def main(args):
     schema_count = 0
 
     all_results = validator.validate_test_data_with_schema()
-    print('  %d results for generated test data' % (len(all_results)))
+    logging.info('  %d results for generated test data', len(all_results))
 
     schema_errors = 0
     failed_validations = []
@@ -92,13 +92,13 @@ def main(args):
 
 
     if schema_errors:
-        print('Test data file files: %d fail out of %d:' % (
-            len(schema_errors, schema_count)))
+        logging.critical('Test data file files: %d fail out of %d:',
+            len(schema_errors, schema_count))
         for failure in schema_errors:
-            print('  %s' % failure)
+            logging.critical('  %s', failure)
         exit(1)
     else:
-        print("All %d generated test data files match with schema" % schema_count)
+        logging.info("All %d generated test data files match with schema", schema_count)
         exit(0)
 
 if __name__ == "__main__":

--- a/schema/check_schemas.py
+++ b/schema/check_schemas.py
@@ -24,7 +24,7 @@ class ValidateSchema():
         failed_validations = []
         passed_validations = []
         for result in validation_status:
-            print(result)
+            logging.debug(result)
             if result['result']:
                 passed_validations.append(result)
             else:
@@ -99,13 +99,13 @@ def main(args):
     ok = val_schema.save_schema_validation_summary(validation_status)
 
     if schema_errors:
-        print('SCHEMA: %d fail out of %d:' % (
-            len(schema_errors), schema_count))
+        logging.error('SCHEMA: %d fail out of %d:', 
+            len(schema_errors), schema_count)
         for failure in schema_errors:
-            print('  %s' % failure)
+            logging.error('  %s', failure)
         exit(1)
     else:
-        print("All %d schema are valid" % schema_count)
+        logging.info("All %d schema are valid", schema_count)
         exit(0)
 
 

--- a/schema/check_test_output.py
+++ b/schema/check_test_output.py
@@ -26,7 +26,7 @@ def main(args):
     else:
         test_output_path = args[1]
 
-    print('TEST OUTPUT PATH = %s' % test_output_path)
+    logging.debug('TEST OUTPUT PATH = %s', test_output_path)
 
     logger = logging.Logger("Checking Test Data vs. Schemas LOGGER")
     logger.setLevel(logging.INFO)
@@ -61,8 +61,8 @@ def main(args):
             icu_version_set.add(os.path.basename(dir))
 
     icu_versions = sorted(list(icu_version_set))
-    print('ICU directories = %s' % icu_versions)
-    print('test types = %s' % ALL_TEST_TYPES)
+    logging.debug('ICU directories = %s', icu_versions)
+    logging.debug('test types = %s', ALL_TEST_TYPES)
 
     validator = schema_validator.ConformanceSchemaValidator()
     # Todo: use setters to initialize validator
@@ -78,7 +78,7 @@ def main(args):
     schema_count = 0
 
     all_results = validator.validate_test_output_with_schema()
-    print('  %d results for generated test data' % (len(all_results)))
+    logging.debug('  %d results for generated test data', len(all_results))
 
     schema_errors = 0
     failed_validations = []
@@ -114,13 +114,13 @@ def main(args):
 
 
     if schema_errors:
-        print('Test data file files: %d fail out of %d:' % (
-            len(schema_errors, schema_count)))
+        logging.error('Test data file files: %d fail out of %d:', 
+            len(schema_errors, schema_count))
         for failure in schema_errors:
-            print('  %s' % failure)
+            logging.error('  %s', failure)
         exit(1)
     else:
-        print("All %d test output files match with schema" % schema_count)
+        logging.info("All %d test output files match with schema", schema_count)
         exit(0)
 
 if __name__ == "__main__":

--- a/schema/check_test_output.py
+++ b/schema/check_test_output.py
@@ -85,7 +85,7 @@ def main(args):
     passed_validations = []
     schema_count = len(all_results)
     for result in all_results:
-        print(result)
+        logging.debug(result)
         if result['result']:
             passed_validations.append(result)
         else:

--- a/schema/schema_validator.py
+++ b/schema/schema_validator.py
@@ -93,10 +93,10 @@ class ConformanceSchemaValidator():
         for test_type in self.test_types:
             for icu_version in self.icu_versions:
                 if self.debug > 0:
-                    logging.debug('Checking test data %s, %s', test_type, icu_version)
+                    logging.info('Checking test data %s, %s', test_type, icu_version)
                 logging.info('Checking %s, %s', test_type, icu_version)
                 result_data =  self.check_test_data_schema(icu_version, test_type)
-                print(result_data)
+                logging.debug('test result data = %s', result_data)
                 msg = result_data['err_info']
                 if not result_data['data_file_name']:
                     # This is not an error but simple a test that wasn't run.
@@ -105,7 +105,7 @@ class ConformanceSchemaValidator():
                     logging.warning('VALIDATION FAILS: %s %s. MSG=%s',
                                     test_type, icu_version, result_data['err_info'])
                 else:
-                    logging.warning('VALIDATION WORKS: %s %s', test_type, icu_version)
+                    logging.info('VALIDATION WORKS: %s %s', test_type, icu_version)
                 all_results.append(result_data)
         return all_results
 
@@ -244,7 +244,7 @@ class ConformanceSchemaValidator():
                         logging.warning('VALIDATION FAILS: %s %s %s. MSG=%s',
                                         test_type, icu_version, executor, results['err_info'])
                     else:
-                        logging.warning('VALIDATION WORKS: %s %s %s', test_type, icu_version, executor)
+                        logging.info('VALIDATION WORKS: %s %s %s', test_type, icu_version, executor)
                     all_results.append(results)
         return all_results
 

--- a/schema/schema_validator.py
+++ b/schema/schema_validator.py
@@ -266,7 +266,7 @@ def process_args(args):
     #   Directory for test result files
     # Get name of test and type
     if len(args) < 2:
-        print('you gotta give me something...')
+        logging.error('Not enough arguments provided')
         return
 
     base_folder = args[1]
@@ -327,10 +327,10 @@ def main(args):
     schema_validator.icu_versions = ['icu71', 'icu72', 'icu73', 'icu74']
     schema_validator.executors = ['node', 'rust', 'dart_web']
 
-    print('Checking test outputs')
+    logging.info('Checking test outputs')
     all_test_out_results = schema_validator.validate_test_output_with_schema()
     for result in all_test_out_results:
-        print('  %s' % result)
+        logging.debug('  %s', result)
 
     # Check all schema files for correctness.
     schema_errors = schema_validator.check_schema_files()
@@ -342,16 +342,16 @@ def main(args):
     icu_versions = ['icu71', 'icu72', 'icu73', 'icu74']
     executor_list = ['node', 'rust', 'dart_web']
 
-    print('Checking generated data')
+    logging.info('Checking generated data')
     all_test_data_results = schema_validator.validate_test_data_with_schema()
     for result in all_test_data_results:
 
-        print('  %s' % result)
+        logging.debug('  %s', result)
 
-    print('Checking test outputs')
+    logging.info('Checking test outputs')
     all_test_out_results = schema_validator.validate_test_output_with_schema()
     for result in all_test_out_results:
-        print('  %s' % result)
+        logging.debug('  %s', result)
     return
 
 if __name__ == "__main__":

--- a/testdriver/datasets.py
+++ b/testdriver/datasets.py
@@ -288,7 +288,7 @@ class ExecutorInfo():
           return system[version]
       return {'path': ExecutorCommands[lang]}  # Nothing found
     except KeyError as err:
-      print('versionForCldr error = %s' % err)
+      logging.error('versionForCldr error = %s', err)
       return {'path': lang}  # Nothing found
 
   def has(self, exec) :
@@ -380,59 +380,55 @@ allExecutors.addSystem(system, DartVersion.Dart3,
 
 # TESTING
 def printExecutors(executors):
-  print('Executor paths:')
+  logging.debug('Executor paths:')
   for lang in executors.systems:
     ex = executors.systems[lang]
-    print('   %s' % (lang))
+    logging.debug('   %s', lang)
     for key in ex.keys():
-      print('     %s: %s' % (key, ex[key]['path']))
+      logging.debug('     %s: %s', key, ex[key]['path'])
 
 def printDatasets(ds):
-  print('Defined datasets:')
+  logging.debug('Defined datasets:')
   for item in ds:
-    print('  %s:' % (item))
-    print('    type: %s' % ds[item].test_type)
-    print('    test filename: %s' % ds[item].testDataFilename)
-    print('    verify filename: %s' % ds[item].verifyFilename)
-    print('    CLDR version: %s' % ds[item].cldr_version)
-    print('    ICU version: %s' % ds[item].icu_version)
+    logging.debug('  %s:', item)
+    logging.debug('    type: %s', ds[item].test_type)
+    logging.debug('    test filename: %s', ds[item].testDataFilename)
+    logging.debug('    verify filename: %s', ds[item].verifyFilename)
+    logging.debug('    CLDR version: %s', ds[item].cldr_version)
+    logging.debug('    ICU version: %s', ds[item].icu_version)
 
 def printCldrIcuMap():
-  print('CLDR version maps')
+  logging.debug('CLDR version maps')
   for name, member in CLDRVersion.__members__.items():
     try:
-      print('  %s in %s' % (name, cldr_icu_map[member]))
+      logging.debug('  %s in %s', name, cldr_icu_map[member])
     except KeyError:
-      print('  %s not in map' % (name))
+      logging.debug('  %s not in map', name)
 
 def main(args):
 
   logging.config.fileConfig("../logging.conf")
 
   printCldrIcuMap()
-  print()
   printDatasets(testDatasets)
-  print()
   printExecutors(allExecutors)
 
-  print()
   cldr_version = CLDRVersion.CLDR41
   ds = dataSetsForCldr(testDatasets, cldr_version)
-  print('test datasets for %s:' % cldr_version)
+  logging.info('test datasets for %s:', cldr_version)
   for label in ds:
-    print('  data file = %s' % (testDatasets[label].testDataFilename))
+    logging.info('  data file = %s', testDatasets[label].testDataFilename)
 
-  print()
-  print('All paths for testing %s' % (cldr_version))
+  logging.info('All paths for testing %s', cldr_version)
   lang = ExecutorLang.NODE
   for lang in [ExecutorLang.NODE, ExecutorLang.RUST, ExecutorLang.CPP,
                'newLanguage']:
     exec = allExecutors.versionsForCldr(lang, cldr_version)
-    print('  executor: %s' % (lang))
+    logging.info('  executor: %s', lang)
     if exec:
-      print('    path: %s argList=%s' % (exec['path'], exec['argList']))
+      logging.debug('    path: %s argList=%s', exec['path'], exec['argList'])
     else:
-      print('    ** No defined path')
+      logging.debug('    ** No defined path for executor\'s CLI command + args')
 
 if __name__ == '__main__':
     main(sys.argv)

--- a/testdriver/ddtargs.py
+++ b/testdriver/ddtargs.py
@@ -20,6 +20,7 @@
 #      faster but not hermetically isolated
 
 import argparse
+import logging
 import sys
 
 class DdtOptions():
@@ -172,12 +173,12 @@ def main(args):
   tests = argsTestData()
   for test in tests:
     try:
-      print('Args = %s' % test)
+      logging.debug('Args = %s' % test)
 
       result = argparse.parse(test)
-      print('  OPTIONS = %s' % argparse.options)
+      logging.debug('  OPTIONS = %s' % argparse.options)
     except BaseException as err:
-      print(' ERROR: %s ' % err)
+      logging.error(' ERROR: %s ' % err)
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/testdriver/testplan.py
+++ b/testdriver/testplan.py
@@ -131,7 +131,7 @@ class TestPlan:
         if self.options.run_limit:
             self.run_limit = int(self.options.run_limit)
             if self.debug:
-                print('!!! RUN LIMIT SET: %d' % self.run_limit)
+                logging.debug('!!! RUN LIMIT SET: %d', self.run_limit)
 
         if self.debug:
             logging.debug('Running plan %s on data %s',
@@ -192,7 +192,7 @@ class TestPlan:
             self.jsonOutput["platform error"] = self.run_error_message
         else:
             if self.debug:
-                print('TERMINATION INFO = %s' % result)
+                logging.debug('TERMINATION INFO = %s', result)
                 self.jsonOutput["platform"] = json.loads(result)
 
     def generate_header(self):
@@ -384,7 +384,7 @@ class TestPlan:
             return []
 
         if self.debug > 2:
-            print('PROCESSING %d tests' % len(tests_to_send))
+            logging.debug('PROCESSING %d tests', len(tests_to_send))
 
         # Ask process to exit when finished.
         out_and_exit = '\n'.join(tests_to_send) + '\n#EXIT'
@@ -425,7 +425,7 @@ class TestPlan:
                 # Extract the message and check if we continue or not.
                 json_start = item.index('{')
                 json_text = item[json_start:]
-                print('JSON TEXT = %s' % json_text)
+                logging.debug('JSON TEXT = %s', json_text)
                 json_out = json.loads(json_text)
                 if 'error_retry' in json_out and json_out['error_retry']:
                     should_retry = json_out['error_retry']

--- a/testdriver/testplan.py
+++ b/testdriver/testplan.py
@@ -134,8 +134,8 @@ class TestPlan:
                 print('!!! RUN LIMIT SET: %d' % self.run_limit)
 
         if self.debug:
-            print('Running plan %s on data %s' % (
-                self.exec_command, self.inputFilePath))
+            logging.debug('Running plan %s on data %s',
+                self.exec_command, self.inputFilePath)
 
         if self.options.exec_mode == 'one_test':
             self.run_one_test_mode()
@@ -156,7 +156,7 @@ class TestPlan:
             return None
         else:
             if self.debug:
-                print('EXECUTOR INFO = %s' % result)
+                logging.debug('EXECUTOR INFO = %s', result)
             try:
                 self.jsonOutput["platform"] = json.loads(result)
                 self.platformVersion = self.jsonOutput["platform"]["platformVersion"]
@@ -230,8 +230,8 @@ class TestPlan:
 
     def run_one_test_mode(self):
         if self.debug:
-            print('  Running OneTestMode %s on data %s' %
-                  (self.exec_command, self.inputFilePath))
+            logging.debug('  Running OneTestMode %s on data %s',
+                  self.exec_command, self.inputFilePath)
 
         # Set up calls for version data --> results
 
@@ -277,11 +277,11 @@ class TestPlan:
         # Create results file
         try:
             if self.debug:
-                logging.info('++++++ Results file path = %s', self.outputFilePath)
+                logging.debug('++++++ Results file path = %s', self.outputFilePath)
                 self.resultsFile = open(self.outputFilePath, encoding='utf-8', mode='w')
         except BaseException as error:
-            print('*** Cannot open results file at %s. Err = %s' %
-                  (self.outputFilePath, error))
+            logging.error('*** Cannot open results file at %s. Err = %s',
+                  self.outputFilePath, error)
             self.resultsFile = open(self.outputFilePath, encoding='utf-8', mode='w')
 
         # Store information the test run
@@ -344,8 +344,8 @@ class TestPlan:
 
             if self.progress_interval and test_num % self.progress_interval == 0:
                 formatted_num = '{:,}'.format(test_num)
-                print('Testing %s / %s. %s of %s' % (
-                    self.exec_list[0], self.testScenario, formatted_num, formatted_count), end='\r')
+                logging.debug('Testing %s / %s. %s of %s', 
+                    self.exec_list[0], self.testScenario, formatted_num, formatted_count)
 
             # Accumulate tests_per_execution items into a single outline
             if lines_in_batch < tests_per_execution:
@@ -358,7 +358,7 @@ class TestPlan:
                     all_test_results.extend(result)
                 else:
                     num_errors += 1
-                    print('!!!!!!  "platform error": "%s",\n' % self.run_error_message)
+                    logging.error('!!!!!!  "platform error": "%s",\n', self.run_error_message)
 
                 # Reset the batch
                 lines_in_batch = 0
@@ -417,7 +417,7 @@ class TestPlan:
                 # TODO: Document these, perhaps in the project's JSON schema.
                 continue
             if item[0] == "#":
-                logging.info('#### DEBUG OUTPUT = %s', item)
+                logging.debug('#### DEBUG OUTPUT = %s', item)
 
             # Process some types of errors
             if item[1:3] == "!!" and self.debug > 1:
@@ -446,7 +446,7 @@ class TestPlan:
         # TODO Implement this
         logging.info('!!! Running MultiTestMode %s on data %s',
                      self.exec_command, self.inputFilePath)
-        print('  ** UNIMPLEMENTED **')
+        logging.warning('  ** UNIMPLEMENTED **')
         # Open the input file and get tests
         # Open results file
 
@@ -475,11 +475,10 @@ class TestPlan:
             try:
                 self.jsonData = json.loads(file_raw)
             except json.JSONDecodeError as error:
-                print('CANNOT parse JSON from file %s: %s' % (self.inputFilePath, error))
+                logging.error('CANNOT parse JSON from file %s: %s', self.inputFilePath, error)
                 return None
         except FileNotFoundError as err:
-            print('*** Cannot open file %s. Err = %s' %
-                  (self.inputFilePath, err))
+            logging.error('*** Cannot open file %s. Err = %s', self.inputFilePath, err)
             return None
 
         try:
@@ -504,9 +503,9 @@ class TestPlan:
             if not result.returncode:
                 return result.stdout
             else:
-                print('$$$$$$$$$$$$$$$$ ---> return code: %s' % result.returncode)
-                print('    ----> INPUT LINE= >%s<' % input_line)
-                print('    ----> STDOUT= >%s<' % result.stdout)
+                logging.debug('$$$$$$$$$$$$$$$$ ---> return code: %s', result.returncode)
+                logging.debug('    ----> INPUT LINE= >%s<', input_line)
+                logging.debug('    ----> STDOUT= >%s<', result.stdout)
                 self.run_error_message = '!!!! ERROR IN EXECUTION: %s. STDERR = %s' % (
                     result.returncode, result.stderr)
                 logging.error(' !!!!!! %s' % self.run_error_message)
@@ -521,7 +520,7 @@ class TestPlan:
                 }
                 return json.dumps(error_result)
         except BaseException as err:
-            print('!!! send_one_line fails: input => %s<. Err = %s' % (input_line, err))
+            logging.error('!!! send_one_line fails: input => %s<. Err = %s', input_line, err)
             input = json.loads(input_line.replace('#EXIT', ''))
             error_result = {'label': input['label'],
                             'input_data': input,

--- a/testgen/testdata_gen.py
+++ b/testgen/testdata_gen.py
@@ -143,7 +143,7 @@ class generateData():
             json.dump(json_verify, num_fmt_verify_file, indent=1)
             num_fmt_verify_file.close()
 
-            logging.warning('NumberFormat Test (%s): %s tests created', self.icu_version, count)
+            logging.info('NumberFormat Test (%s): %s tests created', self.icu_version, count)
         return
 
     def processLangNameTestData(self):

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -774,9 +774,9 @@ class TestReport:
         if self.debug > 0:
             logging.info('--------- %s %s %d failures-----------',
                          self.exec, self.test_type, len(self.failing_tests))
-            logging.info('  SINGLE SUBSTITUTIONS: %s',
+            logging.debug('  SINGLE SUBSTITUTIONS: %s',
                          sort_dict_by_count(self.diff_summary.single_diffs))
-            logging.info('  PARAMETER DIFFERENCES: %s',
+            logging.debug('  PARAMETER DIFFERENCES: %s',
                          sort_dict_by_count(self.diff_summary.params_diff))
 
     def analyze_simple(self, test):

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -979,8 +979,8 @@ class SummaryReport:
                     self.type_summary[test_type].append(test_results)
 
             except BaseException as err:
-                print('SUMMARIZE REPORTS in exec_summary %s, %s. Error: %s' % (
-                    executor, test_type, err))
+                logging.error('SUMMARIZE REPORTS in exec_summary %s, %s. Error: %s', 
+                    executor, test_type, err)
 
     def get_stats(self, entry):
         # Process items in a map to give HTML table value
@@ -1081,8 +1081,8 @@ class SummaryReport:
         html_output = self.templates.summary_html_template.safe_substitute(html_map)
 
         if self.debug > 1:
-            print('HTML OUTPUT =\n%s' % html_output)
-            print('HTML OUTPUT FILEPATH =%s' % self.summary_html_path)
+            logging.debug('HTML OUTPUT =\n%s', html_output)
+            logging.debug('HTML OUTPUT FILEPATH =%s', self.summary_html_path)
         file.write(html_output)
         file.close()
 

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -100,7 +100,6 @@ class Verifier:
         try:
             self.report_file = open(self.report_path, encoding='utf-8', mode='w')
         except BaseException as err:
-            print('*** Cannot open file %s: Error = %s' % (self.report_path, err))
             logging.error('*** Cannot open file %s: Error = %s', self.report_path, err)
             return None
 
@@ -108,7 +107,6 @@ class Verifier:
         try:
             self.testdata_file = open(self.testdata_path, encoding='utf-8', mode='r')
         except BaseException as err:
-            print('*** Cannot open testdata file %s: Error = %s' % (self.testdata_path, err))
             logging.error('*** Cannot open testdata file %s: Error = %s', self.testdata_path, err)
             return None
 

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -72,13 +72,13 @@ class Verifier:
             file_time = os.path.getmtime(self.result_path)
             self.result_timestamp = datetime.datetime.fromtimestamp(file_time).strftime('%Y-%m-%d %H:%M')
         except BaseException as err:
-            print('    *** Cannot open results file %s:\n        %s' % (self.result_path, err))
+            logging.error('    *** Cannot open results file %s:\n        %s', self.result_path, err)
             return None
 
         try:
             self.verify_data_file = open(self.verify_path, encoding='utf-8', mode='r')
         except BaseException as err:
-            print('    **!!* %s: Cannot open verify file %s' % (err, self.verify_path))
+            logging.error('    **!!* %s: Cannot open verify file %s', err, self.verify_path)
             return None
 
         # Create report directory if needed
@@ -90,12 +90,18 @@ class Verifier:
             sys.stderr.write('    !!! Cannot create directory %s for report file %s' %
                              (report_dir, self.report_path))
             sys.stderr.write('   !!! Error = %s' % err)
+
+            logging.error('    !!! Cannot create directory %s for report file %s',
+                             report_dir, self.report_path)
+            logging.error('   !!! Error = %s', err)
+            
             return None
 
         try:
             self.report_file = open(self.report_path, encoding='utf-8', mode='w')
         except BaseException as err:
             print('*** Cannot open file %s: Error = %s' % (self.report_path, err))
+            logging.error('*** Cannot open file %s: Error = %s', self.report_path, err)
             return None
 
         # Get the input file to explain test failures
@@ -103,6 +109,7 @@ class Verifier:
             self.testdata_file = open(self.testdata_path, encoding='utf-8', mode='r')
         except BaseException as err:
             print('*** Cannot open testdata file %s: Error = %s' % (self.testdata_path, err))
+            logging.error('*** Cannot open testdata file %s: Error = %s', self.testdata_path, err)
             return None
 
         # Initialize values for this case.
@@ -115,8 +122,8 @@ class Verifier:
         # Initialize commandline arguments
         verify_info = VerifyArgs(args)
         if self.debug > 1:
-            print('!!! ARGS = %s' % args)
-            print('VERIFY INFO: %s' % verify_info)
+            logging.debug('!!! ARGS = %s', args)
+            logging.debug('VERIFY INFO: %s', verify_info)
         self.set_verify_args(verify_info.getOptions())
 
     def set_verify_args(self, arg_options):
@@ -128,7 +135,7 @@ class Verifier:
 
         self.file_base = arg_options.file_base
         if self.debug > 1:
-            print('TEST TYPES = %s' % self.test_types)
+            logging.debug('TEST TYPES = %s', self.test_types)
 
         if not arg_options.summary_only:
             self.setup_verify_plans()
@@ -152,7 +159,7 @@ class Verifier:
 
                 # TODO: Run for each test_type!
                 if test_type not in ddt_data.testDatasets:
-                    print('**** WARNING: test_type %s not in testDatasets' %
+                    logging.warning('**** WARNING: test_type %s not in testDatasets',
                           test_type)
                     raise ValueError('No test dataset found for test type >%s<' %
                                      self.test_type)
@@ -243,14 +250,14 @@ class Verifier:
 
             self.test_type = vplan.test_type
 
-            print('VERIFY %s: %s %s' % (vplan.exec, self.test_type, vplan.result_path))
+            logging.info('VERIFY %s: %s %s', vplan.exec, self.test_type, vplan.result_path)
             if not self.open_verify_files():
                 continue
             self.compare_test_to_expected()
 
             # Save the results
             if not self.report.save_report():
-                print('!!! Could not save report for (%s, %s)',
+                logging.error('!!! Could not save report for (%s, %s)',
                       vplan.test_type, self.exec)
             else:
                 self.report.create_html_report()
@@ -259,13 +266,14 @@ class Verifier:
             self.report.summarize_failures()
 
             if self.debug > 0:
-                print('\nTEST RESULTS in %s for %s. %d tests found' % (
-                    self.exec, vplan.test_type, len(self.results)))
+                logging.debug('\nTEST RESULTS in %s for %s. %d tests found', 
+                    self.exec, vplan.test_type, len(self.results))
                 try:
                     logging.info('     Platform: %s', self.resultData["platform"])
                     logging.info('     %d Errors running tests', self.report.error_count)
                 except BaseException as err:
                     sys.stderr.write('### Missing fields %s, Error = %s' % (self.resultData, err))
+                    logging.error('### Missing fields %s, Error = %s', self.resultData, err)
 
             # Experimental
             # TODO: Finish difference analysis
@@ -278,10 +286,11 @@ class Verifier:
             self.results = self.resultData['tests']
         except BaseException as err:
             sys.stderr.write('Cannot load %s result data: %s' % (self.result_path, err))
+            logging.error('Cannot load %s result data: %s',  self.result_path, err)
             return None
 
         if self.debug >= 1:
-            print('^^^ Result file has %d entries' % (len(self.results)))
+            logging.debug('^^^ Result file has %d entries', len(self.results))
         self.result_file.close()
 
         try:
@@ -315,10 +324,11 @@ class Verifier:
         except BaseException as err:
             sys.stderr.write('!!! Cannot sort test results by label: %s' % err)
             sys.stderr.flush()
+            logging.error('!!! Cannot sort test results by label: %s', err)
 
         if 'platform_error' in self.resultData:
-            print('PLATFORM ERROR: %s' % self.resultData['platform error'])
-            print('No verify done!!!')
+            logging.error('PLATFORM ERROR: %s', self.resultData['platform error'])
+            logging.error('No verify done!!!')
             return None
 
     def compare_test_to_expected(self):
@@ -343,10 +353,11 @@ class Verifier:
         self.report.test_type = self.test_type
         if not self.verifyExpected:
             sys.stderr.write('No expected data in %s' % self.verify_path)
+            logging.error('No expected data in %s', self.verify_path)
             return None
 
         if not self.results:
-            print('*$*$*$*$* self.results = %s' % self.results)
+            logging.error('*$*$*$*$* self.results = %s', self.results)
             return None
 
         # Loop over all results found, comparing with the expected result.
@@ -357,10 +368,10 @@ class Verifier:
 
         for test in self.results:
             if not test:
-                print('@@@@@ no test string: %s of %s' % (test, len(self.results)))
+                logging.debug('@@@@@ no test string: %s of %s', test, len(self.results))
 
             if index % 10000 == 0:
-                print('  progress = %d / %s' % (index, total_results), end='\r')
+                logging.debug('  progress = %d / %s', index, total_results)
 
             # The input to the test
             try:
@@ -386,7 +397,7 @@ class Verifier:
             verification_data = self.find_expected_with_label(test_label)
 
             if verification_data is None:
-                print('*** Cannot find verify data with label %s' % test_label)
+                logging.warning('*** Cannot find verify data with label %s', test_label)
                 self.report.record_missing_verify_data(test)
                 # Bail on this test
                 continue
@@ -396,9 +407,9 @@ class Verifier:
             except:
                 expected_result = 'UNKNOWN'
             if self.debug > 1:
-                print('VVVVV: %s actual %s, expected %s' % (
+                logging.debug('VVVVV: %s actual %s, expected %s',
                     (actual_result == expected_result),
-                    actual_result, expected_result))
+                    actual_result, expected_result)
             # Remember details about the test
             test['input_data'] = test_data
             test['expected'] = expected_result
@@ -409,7 +420,6 @@ class Verifier:
 
             index += 1
 
-        print('')
         return
 
     def find_expected_with_label(self, test_label):
@@ -422,8 +432,8 @@ class Verifier:
         try:
             return self.verifyExpectedDict[test_label]
         except BaseException as err:
-            print('----- find_expected_with_label %s' % err)
-            print('  No expected item with test_label = %s' % test_label)
+            logging.error('----- find_expected_with_label %s', err)
+            logging.error('  No expected item with test_label = %s', test_label)
         return True
 
     def find_testdata_with_label(self, test_label):
@@ -435,9 +445,9 @@ class Verifier:
         try:
             return self.testdataDict[test_label]
         except BaseException as err:
-            print('----- findTestdataWithLabel %s' % err)
-            print('  No test data item with test_label = %s' % test_label)
-            print('  SUGGESTION: Check if test results are synced with test data!')
+            logging.error('----- findTestdataWithLabel %s', err)
+            logging.error('  No test data item with test_label = %s', test_label)
+            logging.error('  SUGGESTION: Check if test results are synced with test data!')
 
         return True
 
@@ -449,7 +459,7 @@ class Verifier:
     def setup_paths(self, executor, testfile, verify_file):
         base_dir = self.file_base
         if self.debug > 1:
-            print('&&& FILE BASE = %s' % base_dir)
+            logging.deubg('&&& FILE BASE = %s', base_dir)
             # Check on the path defined here
             test_output_dir = 'testOutput'
             self.resultPath = os.path.join(
@@ -459,9 +469,9 @@ class Verifier:
             self.reportPath = os.path.join(
                 base_dir, 'testReports', executor, testfile)
         if self.debug > 0:
-            print('RESULT PATH = %s' % self.resultPath)
-            print('VERIFY PATH = %s' % self.verifyPath)
-            print('TESTDATA PATH = %s' % self.testdata_path)
+            logging.debug('RESULT PATH = %s', self.resultPath)
+            logging.debug('VERIFY PATH = %s', self.verifyPath)
+            logging.debug('TESTDATA PATH = %s', self.testdata_path)
 
     # Create HTML summary files
     def create_summary_reports(self):
@@ -478,7 +488,7 @@ class Verifier:
         # And make the output HTML results
         result = summary_report.create_summary_html()
         if not result:
-            print('!!!!!! SUMMARY HTML fails')
+            logging.error('!!!!!! SUMMARY HTML fails')
 
     def schema_results(self):
         # Locate the files in schema, testData, and testOutput
@@ -589,10 +599,10 @@ class Tester:
             executor, 'display_names.json', 'display_names_verify.json')
 
     def print_result(self):
-        print('\n  Test Report for %s' % self.title)
+        logging.info('\n  Test Report for %s', self.title)
         test_report = self.verifier.report
         report_data = test_report.create_report()
-        print('  Report: %s' % report_data)
+        logging.info('  Report: %s', report_data)
 
 
 # Test basic verifier functions
@@ -622,13 +632,13 @@ def main(args):
 
     if not verifier.options.summary_only:
         # Run the tests on the provided parameters.
-        print('Verifier starting on %d verify cases' % (len(verifier.verify_plans)))
+        logging.info('Verifier starting on %d verify cases', len(verifier.verify_plans))
         verifier.verify_data_results()
-        print('Verifier completed %d data reports' % (len(verifier.verify_plans)))
+        logging.info('Verifier completed %d data reports', len(verifier.verify_plans))
 
     # TODO: Should this be optional?
     verifier.create_summary_reports()
-    print('Verifier completed summary report')
+    logging.info('Verifier completed summary report')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reduce printing to standard output by:

- Adjusting logging levels appropriately
- Converting plain `print()` statements to logging, using appropriate level
- Change log rotation strategy
    - Our Python logging config has more verbose (DEBUG level) logging going to file than the concise (INFO level) logging subset allowed to be repeated to standard output
    - We can rotate the log files so that we can keep a short term history of the output from previous runs
    - The Python `logging.config` may have been invoked multiple times in one end-to-end run (ex: once per executor invocation), because we're not running a single Python executable, but instead multiple instances of smaller disjoint Python executables. Simpler system, but flexibility trades off with convenience. The consequence is log files might be getting overwritten in undesirable unexpected ways
    - Drop the log rotation behavior from the Python logger
    - Use the Linux/Unix tool `logrotate` in a manual way, once per program execution

Overall result: stdout drops from [~30K lines](https://github.com/unicode-org/conformance/actions/runs/6962036710/job/18944907211?pr=134) to only ~650 lines. Full details are still captured across all of the log files.