### PR TITLE
Reclassify Dart results - many to unsupported

### DIFF
--- a/executors/dart_web/bin/likely_subtags.dart
+++ b/executors/dart_web/bin/likely_subtags.dart
@@ -27,6 +27,8 @@ String testLikelySubtags(String jsonEncoded) {
   } catch (error) {
     outputLine.addAll({
       'error_message': error.toString(),
+      'unsupported': 'unsupported subtags',
+      'error_type': 'unsupported',
       'error': 'Failure in locale subtags.'
     });
   }

--- a/executors/dart_web/bin/numberformat.dart
+++ b/executors/dart_web/bin/numberformat.dart
@@ -102,6 +102,8 @@ String testDecimalFormat(
       // This is a special kind of unsupported.
       return jsonEncode({
         'label': label,
+        'unsupported': 'parsing error',
+        'error_type': 'unsupported',
         'error': 'Option parsing error: $e',
       });
     }
@@ -156,6 +158,7 @@ String testDecimalFormat(
     return jsonEncode({
       'label': label,
       'unsupported': 'unsupported_options',
+      'error_type': 'unsupported',
       'error_detail': {'unsupported_options': unsupportedOptions}
     });
   }


### PR DESCRIPTION
This adds information to test results that identify them as unsupported rather than errors. The results should be very similar to those of the NodeJS version.

Please review these proposed changes.