### PR TITLE
Cleaning up Rust executor

### DIFF
--- a/executors/rust/1.3/Cargo.lock
+++ b/executors/rust/1.3/Cargo.lock
@@ -197,24 +197,19 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "cargo_metadata",
- "databake",
  "env_logger",
  "fixed_decimal",
  "icu",
  "icu_datagen",
- "icu_provider",
- "icu_testdata",
  "json",
  "log",
  "rustc_version_runtime",
  "serde",
  "serde_json",
- "substring",
  "writeable",
- "zerovec",
 ]
 
 [[package]]
@@ -748,33 +743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9703f6713044d1c0a1335a6d78ffece4c9380582416ace6feeb608e84d279fc7"
 
 [[package]]
-name = "icu_testdata"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450f30cfb667892b510b3a050ad740e23625bfdfb6f73967baabfaeb4e7aa442"
-dependencies = [
- "icu_calendar",
- "icu_collator",
- "icu_collections",
- "icu_compactdecimal",
- "icu_datetime",
- "icu_decimal",
- "icu_displaynames",
- "icu_list",
- "icu_locid",
- "icu_locid_transform",
- "icu_normalizer",
- "icu_plurals",
- "icu_properties",
- "icu_provider",
- "icu_provider_adapters",
- "icu_segmenter",
- "icu_timezone",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "icu_timezone"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,15 +1096,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "substring"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "syn"

--- a/executors/rust/1.3/Cargo.toml
+++ b/executors/rust/1.3/Cargo.toml
@@ -1,33 +1,23 @@
 [package]
 name = "executor"
-
-version = "0.1.0"
+publish = false
+version = "0.0.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 log = "0.4"
 env_logger = "0.9.1"    
 
-substring = "1.0"
 json = "0.12.4"
-serde = {version = "1.0.171", features = ["derive", "alloc"]}
+serde = "1.0.171"
 serde_json = "1.0.100"
 rustc_version_runtime = "0.1.*"
     
-fixed_decimal = {version="0.5.3"}
-writeable = {version="0.5.2"}
-    
-icu = {version="~1.3", features = ["serde", "icu_compactdecimal", "icu_displaynames"] }
-icu_testdata = {version="~1.3", features = ["icu_compactdecimal", "icu_displaynames"]}
-icu_provider = {version="~1.3", features=["macros"]}
-icu_datagen = { version = "~1.3", default-features = false }
+icu = { version = "~1.3", features = ["serde", "icu_compactdecimal", "icu_displaynames"] }
 
-databake = { version = "0.1.3", features = ["derive"], optional = true}
-zerovec = { version = "0.10.0", features = ["yoke"] }
+fixed_decimal = "0.5.3"
+writeable = "0.5.2"
 
 [build-dependencies]
-cargo_metadata="0.18"
-    
-[features]
+cargo_metadata = "0.18"
+icu_datagen = { version = "~1.3", default-features = false }

--- a/executors/rust/1.3/build.rs
+++ b/executors/rust/1.3/build.rs
@@ -8,7 +8,19 @@ fn main() {
                 "cargo:rustc-env=CONFORMANCE_ICU4X_VERSION={}",
                 package.version
             );
-            return;
         }
     }
+
+    // Get data version information from PackageMetadata
+    // https://crates.io/crates/rustc_version_runtime
+    // https://github.com/serde-rs/json
+
+    println!(
+        "cargo:rustc-env=CONFORMANCE_ICU_VERSION={}",
+        icu_datagen::DatagenProvider::LATEST_TESTED_ICUEXPORT_TAG
+    );
+    println!(
+        "cargo:rustc-env=CONFORMANCE_CLDR_VERSION={}",
+        icu_datagen::DatagenProvider::LATEST_TESTED_CLDR_TAG
+    );
 }

--- a/executors/rust/1.3/src/decimalfmt.rs
+++ b/executors/rust/1.3/src/decimalfmt.rs
@@ -5,22 +5,17 @@ use serde_json::{json, Value};
 use icu::decimal::options;
 use icu::decimal::FixedDecimalFormatter;
 
-use fixed_decimal::FixedDecimal;
-
-use icu::locid::locale;
+use icu::locid::Locale;
 
 // Runs decimal and number formatting given patterns or skeletons.
-pub fn run_numberformat_test(json_obj: &Value) {
-    let provider = icu_testdata::get_provider();
-
+pub fn _todo(json_obj: &Value) -> Result<Value, String> {
     let label = &json_obj["label"].as_str().unwrap();
 
     // Default locale if not specified.
-    let mut langid = locale!("und");
-    if json_obj.get("locale") != None {
-        let locale_name = &json_obj["locale"].as_str().unwrap();
-        langid = icu::locid:Locale::from_str(&locale_name);
-    }
+    let langid: Locale = json_obj
+        .get("locale")
+        .map(|locale_name| locale_name.as_str().unwrap().parse().unwrap())
+        .unwrap_or_default();
 
     let input = &json_obj["input"].as_str().unwrap();
 
@@ -29,19 +24,15 @@ pub fn run_numberformat_test(json_obj: &Value) {
     // !! A test. More options to consider!
     options.grouping_strategy = options::GroupingStrategy::Min2;
 
-    let fdf = FixedDecimalFormatter::try_new_with_buffer_provider(
-        &provider, &langid.into(), options)
+    let fdf = FixedDecimalFormatter::try_new(&langid.into(), options)
         .expect("Data should load successfully");
 
     // Check if the conversion from the string input is OK.
-    let input_num: FixedDecimal = input.parse().expect("valid input format");
+    let input_num = input.parse().expect("valid input format");
     let result_string = fdf.format_to_string(&input_num);
 
-    // Result to stdout.
-    let json_result = json!({
+    Ok(json!({
         "label": label,
-        "result": result_string});
-    print!("{}", json_result);
+        "result": result_string
+    }))
 }
-
-

--- a/executors/rust/1.3/src/displaynames.rs
+++ b/executors/rust/1.3/src/displaynames.rs
@@ -1,39 +1,27 @@
 //! Executor provides tests for DisplayNames.
 
 use serde_json::{json, Value};
-use std::io::{self, Write};
-
-use core::cmp::Ordering;
 
 use icu::displaynames::*;
-use icu::locid::{locale, Locale};
+use icu::locid::Locale;
 
 // Function runs comparison using displaynames
-pub fn run_coll_test(json_obj: &Value) {
+pub fn _todo(json_obj: &Value) -> Result<Value, String> {
     let label = &json_obj["label"].as_str().unwrap();
-    let options = &json_obj["options"].as_str().unwrap();
-    let input = &json_obj["input"].as_str().unwrap();
+    let _options = &json_obj["options"].as_str().unwrap();
+    let input = &json_obj["input"].as_str().unwrap().parse().unwrap();
 
     // Default locale if not specified.
-    let langid = if json_obj.get("locale") != None {
-        let locale_name = &json_obj["locale"].as_str().unwrap();
-        Locale::from_str(&locale_name).unwrap()
-    } else {
-        locale!("und")
-    };
+    let langid: Locale = json_obj
+        .get("locale")
+        .map(|locale_name| locale_name.as_str().unwrap().parse().unwrap())
+        .unwrap_or_default();
 
-    let data_provider = icu_testdata::unstable();
+    let displaynames =
+        LocaleDisplayNamesFormatter::try_new(&langid.into(), Default::default()).unwrap();
 
-    let mut options = DisplayNamesOptions::new();
-
-    let displaynames: DisplayNames =
-        DisplayNames::try_new_unstable(&data_provider, langid.into(), options).unwrap();
-
-    let result = displaynames.of(input);
-
-    let json_result = json!({
+    Ok(json!({
         "label": label,
-        "result": result_string});
-    println!("{}", json_result);
-    io::stdout().flush().unwrap();
+        "result": displaynames.of(input)
+    }))
 }

--- a/executors/rust/1.3/src/main.rs
+++ b/executors/rust/1.3/src/main.rs
@@ -17,22 +17,21 @@
 // https://unicode-org.github.io/icu4x-docs/doc/icu_collator/index.html
 
 mod collator;
+mod decimalfmt;
+mod displaynames;
 mod langnames;
 mod likelysubtags;
 mod numberfmt;
 
-use serde_json::{json, Value};
-
-use std::collections::HashMap;
-
-use std::env;
-use std::io::{self};
-
-// Test modules for each type
 use collator::run_collation_test;
 use langnames::run_language_name_test;
 use likelysubtags::run_likelysubtags_test;
 use numberfmt::run_numberformat_test;
+
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::env;
+use std::io;
 
 // Read from stdin, call functions to get json, output the result.
 fn main() -> io::Result<()> {
@@ -75,19 +74,12 @@ fn main() -> io::Result<()> {
         }
 
         if buffer.starts_with("#VERSION") {
-            // Get data version information from PackageMetadata
-            // https://crates.io/crates/rustc_version_runtime
-            // https://github.com/serde-rs/json
-
-            let icu_version = icu_datagen::DatagenProvider::LATEST_TESTED_ICUEXPORT_TAG;
-            let cldr_version = icu_datagen::DatagenProvider::LATEST_TESTED_CLDR_TAG;
-
             let json_result = json!(
             {
                 "platform": "ICU4X",
                 "platformVersion": std::env!("CONFORMANCE_ICU4X_VERSION"),
-                "icuVersion": icu_version,
-                "cldrVersion": cldr_version,
+                "icuVersion": std::env!("CONFORMANCE_ICU_VERSION"),
+                "cldrVersion": std::env!("CONFORMANCE_CLDR_VERSION"),
             });
             println!("{}", json_result);
         } else {

--- a/executors/rust/1.3/src/numberfmt.rs
+++ b/executors/rust/1.3/src/numberfmt.rs
@@ -9,7 +9,7 @@ use icu::decimal::FixedDecimalFormatter;
 
 use icu::compactdecimal::CompactDecimalFormatter;
 
-use icu::locid::{extensions::unicode::key, locale, Locale};
+use icu::locid::{extensions::unicode::key, Locale};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -56,12 +56,10 @@ pub fn run_numberformat_test(json_obj: &Value) -> Result<Value, String> {
     let label = &json_obj["label"].as_str().unwrap();
 
     // Default locale if not specified.
-    let mut langid = if json_obj.get("locale").is_some() {
-        let locale_name = &json_obj["locale"].as_str().unwrap();
-        locale_name.parse::<Locale>().unwrap()
-    } else {
-        locale!("und")
-    };
+    let mut langid: Locale = json_obj
+        .get("locale")
+        .map(|locale_name| locale_name.as_str().unwrap().parse().unwrap())
+        .unwrap_or_default();
 
     let input = &json_obj["input"].as_str().unwrap();
 
@@ -216,10 +214,9 @@ pub fn run_numberformat_test(json_obj: &Value) -> Result<Value, String> {
     };
 
     // Result to stdout.
-    let json_result = json!({
+    Ok(json!({
         "label": label,
         "result": result_string,
         "actual_options": format!("{option_struct:?}, {options:?}"),
-    });
-    Ok(json_result)
+    }))
 }

--- a/executors/rust/1.4/Cargo.lock
+++ b/executors/rust/1.4/Cargo.lock
@@ -197,15 +197,13 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "cargo_metadata",
  "env_logger",
  "fixed_decimal",
  "icu",
  "icu_datagen",
- "icu_provider",
- "icu_testdata",
  "json",
  "log",
  "rustc_version_runtime",
@@ -755,33 +753,6 @@ name = "icu_segmenter_data"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3673d6698dcffce08cfe8fc5da3c11c3f2c663d5d6137fd58ab2cbf44235ab46"
-
-[[package]]
-name = "icu_testdata"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4520710205b662c6fd83d1f2b29efc0fc44e338e3fc586790e7b3ac965ccbc"
-dependencies = [
- "icu_calendar",
- "icu_collator",
- "icu_collections",
- "icu_compactdecimal",
- "icu_datetime",
- "icu_decimal",
- "icu_displaynames",
- "icu_list",
- "icu_locid",
- "icu_locid_transform",
- "icu_normalizer",
- "icu_plurals",
- "icu_properties",
- "icu_provider",
- "icu_provider_adapters",
- "icu_segmenter",
- "icu_timezone",
- "zerotrie",
- "zerovec",
-]
 
 [[package]]
 name = "icu_timezone"

--- a/executors/rust/1.4/Cargo.toml
+++ b/executors/rust/1.4/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "executor"
-
-version = "0.1.0"
+publish = false
+version = "0.0.0"
 edition = "2021"
 
 [dependencies]
@@ -13,14 +13,12 @@ serde = "1.0.171"
 serde_json = "1.0.100"
 rustc_version_runtime = "0.1.*"
 
-icu = {version="~1.4", features = ["serde", "icu_compactdecimal", "icu_displaynames"] }
-icu_testdata = {version="~1.4", features = ["icu_compactdecimal", "icu_displaynames"]}
-icu_provider = {version="~1.4", features=["macros"]}
-icu_datagen = { version = "~1.4", default-features = false }
+icu = { version = "~1.4", features = ["serde", "icu_compactdecimal", "icu_displaynames"] }
 
-fixed_decimal ="0.5.3"
-writeable ="0.5.2"
+fixed_decimal = "0.5.3"
+writeable = "0.5.2"
 
 [build-dependencies]
-cargo_metadata="0.18"
+cargo_metadata = "0.18"
+icu_datagen = { version = "~1.4", default-features = false }
     


### PR DESCRIPTION
Removed unnecessary deps, included dead modules, moved version detection into build.rs