### PR TITLE
Rust executor: check is_le instead of is_lt

### DIFF
--- a/executors/rust/1.3/src/collator.rs
+++ b/executors/rust/1.3/src/collator.rs
@@ -28,7 +28,7 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
 
     let comparison = collator.compare(str1, str2);
 
-    let result = comparison == Ordering::Less;
+    let result = comparison.is_le();
 
     // TODO: How to do this easier?
     let mut result_string = true;


### PR DESCRIPTION
See #129

I made this change directly in the GitHub UI so I haven't tested it yet. Hopefully CI is helpful :)