### PR TITLE
Dart add `lang_names` testing

### DIFF
--- a/executors/dart_native/bin/executor.dart
+++ b/executors/dart_native/bin/executor.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 import 'dart:convert';
 import 'dart:io';
 import 'package:intl4x/collation.dart';

--- a/executors/dart_web/bin/lang_names.dart
+++ b/executors/dart_web/bin/lang_names.dart
@@ -25,13 +25,13 @@ String testLangNames(String jsonEncoded) {
     final displayNames = Intl(locale: locale).displayNames(options);
     final resultLocale = displayNames.ofLanguage(Locale.parse(languageLabel));
 
-    outputLine['result'] = resultLocale;
     outputLine['label'] = json['label'];
+    outputLine['result'] = resultLocale;
   } catch (error) {
     outputLine.addAll({
       'error': error.toString(),
       'label': json['label'],
-      'locale_label': locale,
+      'locale_label': locale.toLanguageTag(),
       'language_label': languageLabel,
       'test_type': 'display_names',
       'error_type': 'unsupported',

--- a/executors/dart_web/bin/lang_names.dart
+++ b/executors/dart_web/bin/lang_names.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+
+import 'package:intl4x/display_names.dart';
+import 'package:intl4x/intl4x.dart';
+
+String testLangNames(String jsonEncoded) {
+  final json = jsonDecode(jsonEncoded) as Map<String, dynamic>;
+
+  final Locale locale;
+  if (json['locale_label'] != null) {
+    // Fix to use dash, not underscore.
+    final localeJson = json['locale_label'] as String;
+    locale = Locale.parse(localeJson.replaceAll('/_/g', '-'));
+  } else {
+    locale = Locale(language: 'en');
+  }
+  final languageLabel =
+      (json['language_label'] as String).replaceAll('/_/g', '-');
+
+  final outputLine = <String, dynamic>{};
+  try {
+    final options = DisplayNamesOptions(
+      languageDisplay: LanguageDisplay.standard,
+    );
+    final displayNames = Intl(locale: locale).displayNames(options);
+    final resultLocale = displayNames.ofLanguage(Locale.parse(languageLabel));
+
+    outputLine['result'] = resultLocale;
+    outputLine['label'] = json['label'];
+  } catch (error) {
+    outputLine.addAll({
+      'error': error.toString(),
+      'label': json['label'],
+      'locale_label': locale,
+      'language_label': languageLabel,
+      'test_type': 'display_names',
+      'error_type': 'unsupported',
+      'error_retry': false // Do not repeat
+    });
+  }
+  return jsonEncode(outputLine);
+}

--- a/executors/dart_web/bin/lang_namesExecutor.dart
+++ b/executors/dart_web/bin/lang_namesExecutor.dart
@@ -1,0 +1,5 @@
+import 'lang_names.dart';
+
+void main(List<String> args) {
+  testLangNames(args.first); //just some call to not treeshake the function
+}

--- a/executors/dart_web/out/executor.js
+++ b/executors/dart_web/out/executor.js
@@ -22,6 +22,8 @@ let numberformatter = require('./numberformat.js')
 
 let likely_subtags = require('./likely_subtags.js')
 
+let lang_names = require('./lang_names.js');
+
 const { dartVersion } = require('./version.js')
 
 /**
@@ -183,6 +185,8 @@ rl.on('line', function (line) {
           outputLine = numberformatter.testDecimalFormat(parsedJson, doLogInput > 0, process.version);
         } else if (test_type == "likely_subtags") {
           outputLine = likely_subtags.testLikelySubtags(parsedJson);
+        } else if (test_type == "language_display_name" || test_type == "lang_names") {
+          outputLine = lang_names.testLangNames(parsedJson);
         } else {
           outputLine = {
             'error': 'unknown test type', 'testId': testId,

--- a/executors/dart_web/out/lang_names.js
+++ b/executors/dart_web/out/lang_names.js
@@ -1,0 +1,7 @@
+var tools = require('./lang_namesDart');
+
+module.exports = {
+    testLangNames: function (json) {
+        return JSON.parse(tools.testLangNames(JSON.stringify(json)));
+    }
+};

--- a/executors/dart_web/pubspec.yaml
+++ b/executors/dart_web/pubspec.yaml
@@ -1,6 +1,4 @@
 name: dart_web
-description: A sample command-line application.
-version: 1.0.0
 publish_to: none
 
 environment:
@@ -12,5 +10,5 @@ dependencies:
   pubspec_lock_parse: ^2.2.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   test: ^1.21.0

--- a/run_config.json
+++ b/run_config.json
@@ -83,6 +83,7 @@
       "test_type": [
         "collation_short",
         "number_fmt",
+        "lang_names",
         "likely_subtags"
       ],
       "per_execution": 10000


### PR DESCRIPTION
Add testing for `lang_names` for Dart Web using `package:intl4x`.