### PR TITLE
Add optional test_types flag to testdata_gen script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,13 +18,14 @@ fi
 
 # ensure that the Python `enum` module is installed
 # Github Actions uses Python 3.11 as of Feb 2024
-check_enum_cmd = "python3 -c 'import pkgutil
-if pkgutil.find_loader(\"enum\"):
-    print(\"The enum module is already installed\")
+python3 -c 'import pkgutil
+if pkgutil.find_loader("enum"):
+    print("The enum module is already installed")
 else:
+    print("The enum module is not installed yet")
     sys.exit(1)
-'"
-`$check_enum_cmd` || error_code=$?
+'
+error_code=$?
 if [[ $error_code -ne 0 ]]
 then
     sudo apt-get install python3-enum34

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,20 @@ fi
 if [[ ! -d gh-cache ]]
 then
     mkdir -p gh-cache
+fi
 
+# ensure that the Python `enum` module is installed
+# Github Actions uses Python 3.11 as of Feb 2024
+check_enum_cmd = "python3 -c 'import pkgutil
+if pkgutil.find_loader(\"enum\"):
+    print(\"The enum module is already installed\")
+else:
+    sys.exit(1)
+'"
+`$check_enum_cmd` || error_code=$?
+if [[ $error_code -ne 0 ]]
+then
+    sudo apt-get install python3-enum34
 fi
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ then
 fi
 
 # ensure that the Python `enum` module is installed
-# Github Actions uses Python 3.11 as of Feb 2024
+# Github Actions uses Python 3.10 as of Feb 2024
 python3 -c 'import pkgutil
 if pkgutil.find_loader("enum"):
     print("The enum module is already installed")

--- a/testgen/testdata_gen.py
+++ b/testgen/testdata_gen.py
@@ -9,7 +9,7 @@ import multiprocessing as mp
 import os
 import re
 import requests
-from enum import StrEnum
+from enum import Enum
 
 reblankline = re.compile('^\s*$')
 
@@ -22,7 +22,7 @@ NUMBERS_TO_TEST = ['0', '91827.3645', '-0.22222']
 NUMBERFORMAT_LOCALE_INDICES = [3, 7, 11]
 
 
-class TestType(StrEnum):
+class TestType(str, Enum):
     NUMBER_FMT = 'number_fmt'
     COLLATION_SHORT = 'collation_short'
     LANG_NAMES = 'lang_names'
@@ -1047,6 +1047,7 @@ def generate_versioned_data_parallel(args):
 
     return result
 
+
 def generate_versioned_data(version_info):
     new_args = version_info['args']
     icu_version = version_info['icu_version']
@@ -1087,4 +1088,4 @@ def main():
 
 
 if __name__ == '__main__':
-  main()
+    main()


### PR DESCRIPTION
For certain use-cases, it is convenient to generate the JSONs for one test type rather than generating all tests each time (for example, when adding a new test type with a different schema). Passing a flag to the script is cleaner than making temporary code changes during development.

This PR adds that flag, which can be used as follows:

Run all tests (pre-existing behavior):
```
python testdata_gen.py --icu_versions icu74
```

Run a subset:
```
python testdata_gen.py --icu_versions icu74 --test_types number_fmt lang_names
```