### PR TITLE
Temporarily remove dart_native from platforms

### DIFF
--- a/run_config.json
+++ b/run_config.json
@@ -90,16 +90,6 @@
     }
   },
   {
-    "run": {
-      "icu_version": "icu73",
-      "exec": "dart_native",
-      "test_type": [
-        "collation_short"
-      ],
-      "per_execution": 10000
-    }
-  },
-  {
     "prereq": {
       "name": "nvm 21.6.0, icu74.1",
       "version": "20.1.0",


### PR DESCRIPTION
An error in Dart Native is blocking continuous integration of updates. This PR removes dart_native so the CI can work again.

"The problem is the use of the @ResourceIdentifier annotation in package:intl4x, introduced by https://github.com/dart-lang/i18n/pull/795. The implementation was faulty, which is now fixed in the Dart SDK. To not get an error, pin the version of intl4x to an earlier one (but that will probably also mean losing all new features introduced since), or wait for the implementation in the Dart SDK to propagate into the newest version, which should be quite soon."