### PR TITLE
Remove the "type" field from list format schema

### DIFF
--- a/schema/list_fmt/test_schema.json
+++ b/schema/list_fmt/test_schema.json
@@ -95,11 +95,6 @@
                "type": "string",
                "enum": ["long", "short", "narrow"]
              },
-             "type": {
-               "description": "Deprecated! The kind of connection between list items, e.g., and/or/none",
-               "type": "string",
-               "enum": ["conjunction", "disjunction", "unit"]
-             },
              "list_type": {
                "description": "The kind of connection between list items, e.g., and/or/none",
                "type": "string",


### PR DESCRIPTION
#231

This is a trial to see if we still need the field, or if the field is gone.