### PR TITLE
message_fmt2: Update error types in schema

### DIFF
--- a/schema/message_fmt2/testgen_schema.json
+++ b/schema/message_fmt2/testgen_schema.json
@@ -351,12 +351,11 @@
               "unresolved-variable",
               "unknown-function",
               "unsupported-expression",
-              "invalid-expression",
-              "operand-mismatch",
-              "unsupported-statement",
-              "selection-error",
-              "formatting-error",
-              "bad-input"
+              "bad-selector",
+              "bad-operand",
+              "bad-option",
+              "bad-variant-key",
+              "unsupported-statement"
             ]
           }
         }

--- a/testgen/icu75/message_fmt2/message-format-wg-tests/functions/date.json
+++ b/testgen/icu75/message_fmt2/message-format-wg-tests/functions/date.json
@@ -11,7 +11,7 @@
       "exp": "{:date}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
@@ -20,7 +20,7 @@
       "exp": "{|horse|}",
       "expErrors": [
         {
-          "type": "operand-mismatch"
+          "type": "bad-operand"
         }
       ]
     },

--- a/testgen/icu75/message_fmt2/message-format-wg-tests/functions/datetime.json
+++ b/testgen/icu75/message_fmt2/message-format-wg-tests/functions/datetime.json
@@ -11,7 +11,7 @@
       "exp": "{:datetime}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
@@ -26,7 +26,7 @@
       ],
       "expErrors": [
         {
-          "type": "bad-input"
+          "type": "bad-operand"
         }
       ]
     },
@@ -35,7 +35,7 @@
       "exp": "{|horse|}",
       "expErrors": [
         {
-          "type": "operand-mismatch"
+          "type": "bad-operand"
         }
       ]
     },

--- a/testgen/icu75/message_fmt2/message-format-wg-tests/functions/number.json
+++ b/testgen/icu75/message_fmt2/message-format-wg-tests/functions/number.json
@@ -22,34 +22,34 @@
       "exp": "hello {|foo|}",
       "expErrors": [
         {
-          "type": "operand-mismatch"
+          "type": "bad-operand"
         }
       ]
     },
     {
-      "src": "invalid number literal {.1 :number}",
+      "src": "invalid number literal {|.1| :number}",
       "exp": "invalid number literal {|.1|}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
     {
-      "src": "invalid number literal {1. :number}",
+      "src": "invalid number literal {|1.| :number}",
       "exp": "invalid number literal {|1.|}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
     {
-      "src": "invalid number literal {01 :number}",
+      "src": "invalid number literal {|01| :number}",
       "exp": "invalid number literal {|01|}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
@@ -58,16 +58,16 @@
       "exp": "invalid number literal {|+1|}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
     {
-      "src": "invalid number literal {0x1 :number}",
+      "src": "invalid number literal {|0x1| :number}",
       "exp": "invalid number literal {|0x1|}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
@@ -76,7 +76,7 @@
       "exp": "hello {:number}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
@@ -139,7 +139,7 @@
       "exp": "bar {$bar}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-option"
         }
       ]
     },
@@ -154,7 +154,7 @@
       "exp": "bar {$bar}",
       "expErrors": [
         {
-          "type": "bad-input"
+          "type": "bad-operand"
         }
       ]
     },
@@ -189,7 +189,7 @@
       "exp": "bar {$foo}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-option"
         }
       ]
     },
@@ -204,7 +204,7 @@
       "exp": "bar {$foo}",
       "expErrors": [
         {
-          "type": "bad-input"
+          "type": "bad-operand"
         }
       ]
     },
@@ -312,26 +312,6 @@
     },
     {
       "src": ".input {$bar :number} .match {$bar} one {{one}} * {{other}}",
-      "params": [
-        {
-          "name": "bar",
-          "value": 2
-        }
-      ],
-      "exp": "other"
-    },
-    {
-      "src": ".input {$bar} .match {$bar :number} one {{one}} * {{other}}",
-      "params": [
-        {
-          "name": "bar",
-          "value": 1
-        }
-      ],
-      "exp": "one"
-    },
-    {
-      "src": ".input {$bar} .match {$bar :number} one {{one}} * {{other}}",
       "params": [
         {
           "name": "bar",

--- a/testgen/icu75/message_fmt2/message-format-wg-tests/functions/time.json
+++ b/testgen/icu75/message_fmt2/message-format-wg-tests/functions/time.json
@@ -11,7 +11,7 @@
       "exp": "{:time}",
       "expErrors": [
         {
-          "type": "invalid-expression"
+          "type": "bad-operand"
         }
       ]
     },
@@ -20,7 +20,7 @@
       "exp": "{|horse|}",
       "expErrors": [
         {
-          "type": "operand-mismatch"
+          "type": "bad-operand"
         }
       ]
     },


### PR DESCRIPTION
Update the error list in testgen_schema.json to match the schema in the MFWG spec repo,
https://github.com/unicode-org/message-format-wg/blob/main/test/schemas/v0/tests.schema.json

Also update function tests to match the schema (just copied the tests from the current MFWG spec repo).