### PR TITLE
message_fmt2: Add duplicate-variant error

### DIFF
--- a/schema/message_fmt2/testgen_schema.json
+++ b/schema/message_fmt2/testgen_schema.json
@@ -377,6 +377,7 @@
               "missing-selector-annotation",
               "duplicate-declaration",
               "duplicate-option-name",
+              "duplicate-variant",
               "unresolved-variable",
               "unknown-function",
               "unsupported-expression",


### PR DESCRIPTION
This error was recently added to the spec
(see https://github.com/unicode-org/message-format-wg/commit/5612f3b0508d63770b218d581c465aae878f5573 )