### PR TITLE
ICU4J Relative Date Time Format: Add number system to locale

### DIFF
--- a/executors/icu4j/74/executor-icu4j/src/main/java/org/unicode/conformance/testtype/relativedatetimeformat/RelativeDateTimeFormatTester.java
+++ b/executors/icu4j/74/executor-icu4j/src/main/java/org/unicode/conformance/testtype/relativedatetimeformat/RelativeDateTimeFormatTester.java
@@ -26,11 +26,16 @@ public class RelativeDateTimeFormatTester implements ITestType {
     result.locale = (String) inputMapData.get("locale", null);
     result.count = (String) inputMapData.get("count", "0");
     result.quantity = Double.parseDouble(result.count);
-
-    result.numberingSystem = (String) inputMapData.get("numbering_system", null);
+    result.numberingSystem = "";
 
     java.util.Map<String, Object> inputOptions =
         (java.util.Map<String, Object>) inputMapData.get("options", null);
+    if (inputOptions != null) {
+      result.numberingSystem = (String) inputOptions.get("numberingSystem");
+      if (result.numberingSystem != "") {
+        result.locale = result.locale + "-u-nu-" + result.numberingSystem;
+      }
+    }
 
     result.style = RelativeDateTimeFormatStyle.getFromString(
         "" + inputOptions.get("style")

--- a/executors/icu4j/74/executor-icu4j/src/test/java/org/unicode/conformance/relativedatetimeformat/icu74/RelativeDateTimeFormatTest.java
+++ b/executors/icu4j/74/executor-icu4j/src/test/java/org/unicode/conformance/relativedatetimeformat/icu74/RelativeDateTimeFormatTest.java
@@ -85,4 +85,19 @@ public class RelativeDateTimeFormatTest {
 
     assertEquals("in 𞥑𞥐y", output.result);
   }
+
+  @Test
+  public void testArabicNumSystem() {
+
+  // Expect Eastern Arabic numerals in the output
+  String testInput =
+      "\t{\"test_type\": \"rdt_fmt\", \"unit\":\"second\",\"count\":\"-100\",\"locale\":\"en-US\",\"options\":{\"numberingSystem\":\"arab\"},\"hexhash\":\"d12df88777f8c7f60130df51d2954e18ec42b9c8\",\"label\":\"704\"}";
+
+  RelativeDateTimeFormatOutputJson output =
+      (RelativeDateTimeFormatOutputJson) RelativeDateTimeFormatTester.INSTANCE.getStructuredOutputFromInputStr(
+          testInput);
+
+  assertEquals("١٠٠ seconds ago",output.result);
+}
+
 }


### PR DESCRIPTION
This reduces test failures in RDTF in ICU4J from 11,237 to 4,830 (icu75)