### PR TITLE
Remove 'und' as a locale in testing

### DIFF
--- a/testgen/generators/datetime_gen.js
+++ b/testgen/generators/datetime_gen.js
@@ -31,13 +31,14 @@ let use_milliseconds = false;
 const numbering_systems = ['latn', 'arab', 'beng']
 
 // ICU4X locales, maybe 20
+// Don't include "und" as a locale because the behavior depends on the platform.
 const locales = [
   'en-US', 'en-GB',
   'zh-TW', 'vi', 'ar', 'mt-MT',
-  'bn', 'zu',
-  'und'];
+  'bn', 'zu'
+]:
 
-// maybe 10 calendars
+      // maybe 10 calendars
 const calendars = ['gregory',
                    'buddhist', 'hebrew', 'chinese', 'roc', 'japanese',
                    'islamic', 'islamic-umalqura', 'persian'
@@ -246,11 +247,11 @@ const dt_fields = {
   },
   'minute': {
     'numeric': 'm',
-  //  '2-digit': 'mm'
+    //  '2-digit': 'mm'
   },
   'second': {
     'numeric': 's',
-//    '2-digit': 'ss'
+    //    '2-digit': 'ss'
   },
   'fractionalSecondDigits': {
     1:'S', 2:'SS', 3:'SSS'},

--- a/testgen/generators/list_fmt_gen.js
+++ b/testgen/generators/list_fmt_gen.js
@@ -14,10 +14,11 @@ const fs = require('node:fs');
 
 let debug = false;
 
-const locales = ['und',
-                 'en-US', 'zh-TW', 'es',
-                 'pt', 'vi', 'el', 'mt-MT', 'ru', 'en-GB',
-                 'bn', 'ar','mr', 'zu'];
+// Don't include "und" as a locale because the behavior depends on the platform.
+const locales = [
+  'en-US', 'zh-TW', 'es',
+  'pt', 'vi', 'el', 'mt-MT', 'ru', 'en-GB',
+  'bn', 'ar','mr', 'zu'];
 
 const types = ['conjunction', 'disjunction', 'unit'];
 
@@ -122,11 +123,11 @@ function generateAll() {
           // TODO: Save this as a test case.
           let test_list;
           let test_case = {
-                           'input_list': list,
-                           'options': {...all_options}
-                          };
+            'input_list': list,
+            'options': {...all_options}
+          };
           gen_hash.generate_hash_for_test(test_case);
-            test_case['label'] = label_string;
+          test_case['label'] = label_string;
 
           if (locale != '') {
             test_case["locale"] = locale;

--- a/testgen/generators/rdt_fmt_gen.js
+++ b/testgen/generators/rdt_fmt_gen.js
@@ -21,11 +21,12 @@ const debug = false;
 // Add numbering system to the test options
 const numbering_systems = [null, 'latn', 'arab', 'beng', 'adlm']
 
+// Don't include "und" as a locale because the behavior depends on the platform.
 const locales = [
   'en-US', 'en-GB',
   'zh-TW', 'vi', 'el', 'mt-MT',
   'bn', 'zu',
-  'und'];
+];
 
 const spec_options = [null,
                       {'style': 'long'},

--- a/verifier/testreport.py
+++ b/verifier/testreport.py
@@ -589,6 +589,9 @@ class TestReport:
         for test in test_list:
             # Get input_data, if available
             input_data = test.get('input_data', None)
+            if not input_data:
+                # Why no data?
+                continue
 
             label = test.get('label', '')
 


### PR DESCRIPTION
This reduces test failures because the "und" locale can produce platoform-specific results.