### PR TITLE
message_fmt2: Make schema more consistent with schema in WG repo

### DIFF
--- a/schema/message_fmt2/testgen_schema.json
+++ b/schema/message_fmt2/testgen_schema.json
@@ -119,14 +119,14 @@
         "src": {
           "$ref": "#/$defs/src"
         },
+        "bidiIsolation": {
+          "$ref": "#/$defs/bidiIsolation"
+        },
         "params": {
           "$ref": "#/$defs/params"
         },
         "exp": {
           "$ref": "#/$defs/exp"
-        },
-        "expCleanSrc": {
-          "$ref": "#/$defs/expCleanSrc"
         },
         "expParts": {
           "$ref": "#/$defs/expParts"
@@ -150,6 +150,9 @@
         "src": {
           "$ref": "#/$defs/src"
         },
+        "bidiIsolation": {
+          "$ref": "#/$defs/bidiIsolation"
+        },
         "params": {
           "$ref": "#/$defs/params"
         },
@@ -158,9 +161,6 @@
         },
         "exp": {
           "$ref": "#/$defs/exp"
-        },
-        "expCleanSrc": {
-          "$ref": "#/$defs/expCleanSrc"
         },
         "expParts": {
           "$ref": "#/$defs/expParts"
@@ -202,6 +202,10 @@
           "items": { "type": "string" }
         }
       ]
+    },
+    "bidiIsolation": {
+      "description": "The bidi isolation strategy.",
+      "enum": ["default", "none"]
     },
     "params": {
       "description": "Parameters to pass in to the formatter for resolving external variables.",
@@ -256,10 +260,6 @@
       "description": "The expected result of formatting the message to a string.",
       "type": "string"
     },
-    "expCleanSrc": {
-      "description": "The expected normalized form of `src`, for testing stringifiers.",
-      "type": "string"
-    },
     "expParts": {
       "description": "The expected result of formatting the message to parts.",
       "type": "array",
@@ -279,6 +279,23 @@
               },
               "value": {
                 "type": "string"
+              }
+            }
+          },
+          {
+            "description": "Bidi isolation part.",
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "const": "bidiIsolation"
+              },
+              "value": {
+                "enum": ["\u2066", "\u2067", "\u2068", "\u2069"]
               }
             }
           },
@@ -306,6 +323,9 @@
                 "type": "string"
               },
               "name": {
+                "type": "string"
+              },
+              "id": {
                 "type": "string"
               },
               "options": {
@@ -384,12 +404,10 @@
               "duplicate-variant",
               "unresolved-variable",
               "unknown-function",
-              "unsupported-expression",
               "bad-selector",
               "bad-operand",
               "bad-option",
-              "bad-variant-key",
-              "unsupported-statement"
+              "bad-variant-key"
             ]
           }
         }
@@ -416,11 +434,6 @@
         {
           "required": [
             "exp"
-          ]
-        },
-        {
-          "required": [
-            "expCleanSrc"
           ]
         },
         {


### PR DESCRIPTION
* Add `bidiIsolation` property that was recently added
* Remove `expCleanSrc` property that is no longer used
* Add "Bidi isolation part" variant to `expParts`
* Remove `unsupported-statement` and `unsupported-expression` from enum in `expErrors`