### PR TITLE
Add NodeJS 23.3.0 supporting ICU76

### DIFF
--- a/run_config.json
+++ b/run_config.json
@@ -130,6 +130,28 @@
   },
   {
     "prereq": {
+      "name": "nvm 23.3.0, icu76.1",
+      "version": "23.3.0",
+      "command": "nvm install 23.3.0;nvm use 23.3.0 --silent"
+    },
+    "run": {
+      "icu_version": "icu76",
+      "exec": "node",
+      "test_type": [
+        "collation_short",
+        "datetime_fmt",
+        "list_fmt",
+        "number_fmt",
+        "lang_names",
+        "likely_subtags",
+        "rdt_fmt",
+        "plural_rules"
+      ],
+      "per_execution": 10000
+    }
+  },
+  {
+    "prereq": {
       "name": "nvm 22.9.0, icu75.1",
       "version": "22.9.0",
       "command": "nvm install 22.9.0;nvm use 22.9.0 --silent"

--- a/testdriver/datasets.py
+++ b/testdriver/datasets.py
@@ -218,7 +218,8 @@ class ParallelMode(Enum):
   ParallelByLang = 2
 
 class NodeVersion(Enum):
-  Node22 = "22.1.0"
+  Node23 = "23.3.0"
+  Node22 = "22.9.0"
   Node21 = "21.6.0"
   Node19 = "19.7.0"
   Node18_7 = "18.7.0"
@@ -248,7 +249,8 @@ class ICU4XVersion(Enum):
 # TODO: combine the version info
 IcuVersionToExecutorMap = {
     'node': {
-        '75': ["22.1.0"],
+        '76': ["23.3.0"],
+        '75': ["22.9.0"],
         '74': ["21.6.0"],
         '73': ["20.1.0"],
         '72': ['18.14.2'],
@@ -272,7 +274,8 @@ IcuVersionToExecutorMap = {
 # What versions of NodeJS use specific ICU versions
 # https://nodejs.org/en/download/releases/
 NodeICUVersionMap = {
-    '22.1.0': '75.1',
+    '23.3.0': '76.1',
+    '22.9.0': '75.1',
     '21.6.0': '74.1',
     '20.1.0': '73.1',
     '18.14.2': '72.1',

--- a/testgen/generators/datetime_fmt.py
+++ b/testgen/generators/datetime_fmt.py
@@ -122,7 +122,8 @@ class DateTimeFmtGenerator(DataGenerator):
     def process_test_data(self):
         # Use NOde JS to create the .json files
         icu_nvm_versions = {
-            'icu75': '22.1.0',
+            'icu76': '23.3.0',
+            'icu75': '22.9.0',
             'icu74': '21.6.0',
             'icu73': '20.1.0',
             'icu72': '18.14.2',

--- a/testgen/generators/list_fmt.py
+++ b/testgen/generators/list_fmt.py
@@ -15,7 +15,8 @@ class ListFmtGenerator(DataGenerator):
     def process_test_data(self):
         # Use Node JS to create the .json files
         icu_nvm_versions = {
-            'icu75': '22.1.0',
+            'icu76': '23.3.0',
+            'icu75': '22.9.0',
             'icu74': '21.6.0',
             'icu73': '20.1.0',
             'icu72': '18.14.2',

--- a/testgen/generators/relativedatetime_fmt.py
+++ b/testgen/generators/relativedatetime_fmt.py
@@ -15,7 +15,8 @@ class RelativeDateTimeFmtGenerator(DataGenerator):
     def process_test_data(self):
         # Use NOde JS to create the .json files
         icu_nvm_versions = {
-            'icu75': '22.1.0',
+            'icu76': '23.3.0',
+            'icu75': '22.9.0',
             'icu74': '21.6.0',
             'icu73': '20.1.0',
             'icu72': '18.14.2',


### PR DESCRIPTION
This also adds ICU76 testing for list format and relative date time because those generators use NodeJS data.