### PR TITLE
Change link color depending on passing status

### DIFF
--- a/verifier/summary_template.html
+++ b/verifier/summary_template.html
@@ -191,6 +191,7 @@
                   let data = [data_groups];
                   let details = [];
                   for (const report of tests) {
+                      background_color = null;
                       if (report['version']['platform'] == exec) {
                           reports.push(report);
                           // Add data for this report.
@@ -208,7 +209,6 @@
                           ];
                           data.push(report_data);
                           // Set the link background color based on status.
-                          background_color = null;
                           // Check if everything is passing to make a visual note
                           if (report['fail_count'] == 0 && report['error_count'] == 0) {
                             // No failures or errors
@@ -268,10 +268,6 @@
                   }
                   td = tr.insertCell();
                   td.innerHTML = details.join('');
-                  if (background_color && td.firstChild) {
-                      // Modify the link's appearance
-                      td.firstChild.style.backgroundColor = background_color;
-                  }        
               }
               }
           }

--- a/verifier/summary_template.html
+++ b/verifier/summary_template.html
@@ -178,8 +178,7 @@
               td.innerHTML = "Details";
           }
 
-          let tr;
-          td;
+          let background_color;
           for (const test_type of test_types) {
               tr = table.insertRow();
               td = tr.insertCell();
@@ -208,12 +207,36 @@
                               ''
                           ];
                           data.push(report_data);
-                          let link = '<a href="' +
+                          // Set the link background color based on status.
+                          background_color = null;
+                          // Check if everything is passing to make a visual note
+                          if (report['fail_count'] == 0 && report['error_count'] == 0) {
+                            // No failures or errors
+                            if (report['known_issue_count'] == 0) {
+                              if (report['unsupported_count'] == 0) {
+                                  background_color = '#00ee88';
+                              } else {
+                                  // No failures, but there are unsupported items
+                                  background_color = '#aaaaaa';
+                              }
+                            } else if (report['unsupported_count'] == 0) {
+                                // Only known issues are present
+                                background_color = '#ffa400';
+                            }
+                         }
+                       // Insert the background color to the link if needed.
+                       let color_part = '';
+                       if (background_color) {
+                           color_part = 'style="background-color:' + background_color + '" ';
+                       }
+                       let href_part = 'href="' +
                               report['html_file_name'] + '"' +
                               ' target="_blank">' +
                               report['icu_version'] +
                               '</a><br />';
-                          details.push(link);
+
+                         let link = '<a ' + color_part + href_part;
+                         details.push(link);
                       }
                   }
                   td = tr.insertCell();
@@ -245,6 +268,10 @@
                   }
                   td = tr.insertCell();
                   td.innerHTML = details.join('');
+                  if (background_color && td.firstChild) {
+                      // Modify the link's appearance
+                      td.firstChild.style.backgroundColor = background_color;
+                  }        
               }
               }
           }


### PR DESCRIPTION
#350 

This PR affects the links to detail pages, e.g., ICU4C testing of list_format in ICU76.

If there are no fail tests or error results, then the link may be of different colors:
  * All pass --> green background
  * All either pass or are unsupported --> gray background
  * All either pass or are known issues --> light orange background.