### PR TITLE
Node and collation: fix errors, add 'actual_options'

### DIFF
--- a/executors/node/collator.js
+++ b/executors/node/collator.js
@@ -57,18 +57,29 @@ module.exports = {
           outputLine['error_detail'] = 'No rules';
           outputLine['error'] = 'rules';
         }
-        else if (compare_type) {
-          outputLine['unsupported'] = 'Compare type not supported';
-          outputLine['error_detail'] = 'No comparison';
-          outputLine['error'] = 'compare_type';
+        else {
+          outputLine['actual_options'] = JSON.stringify(coll.resolvedOptions());  //.toString();
+          outputLine['compare_result'] = compared;
+          outputLine['result'] = result_bool;
         }
       }
 
     } catch (error) {
-      outputLine =  {'label': json['label'],
-                     'error_message': 'LABEL: ' + json['label'] + ' ' + error.message,
-                     'error': 'Collator compare failed'
-                 };
+      const error_message = error.message;
+
+      if (testLocale == "root" || error_message == "Incorrect locale information provided")  {
+        outputLine =  {'label': json['label'],
+                       'unsupported': 'root locale',
+                       'error_detail': error_message + ': ' + testLocale,
+                       'error': 'Unsupported locale'
+                      };
+      } else {
+        outputLine =  {'label': json['label'],
+                       'error_message': error_message,
+                       'error_detail': testLocale,
+                       'error': 'Something wrong'
+                      };
+      }
     }
     return outputLine;
   }

--- a/schema/collation_short/result_schema.json
+++ b/schema/collation_short/result_schema.json
@@ -84,7 +84,7 @@
            "type": "string"
          },
          "actual_options": {
-           "description": "What was sent to the collation function",
+           "description": "Options used by collation as a string",
            "type": "string"
          },
          "input_data": {

--- a/testgen/generators/base.py
+++ b/testgen/generators/base.py
@@ -68,7 +68,7 @@ class DataGenerator(ABC):
 
             # Create the 32 byte hasn, consisten with Javascript
             hasher = hashlib.sha1()
-            hasher.update(test_no_label_string.encode("utf_8"))
+            hasher.update(test_no_label_string.encode("utf-8"))
             hex_digest = hasher.hexdigest()
             test['hexhash'] = hex_digest
 
@@ -82,7 +82,7 @@ class DataGenerator(ABC):
                               filename)
 
         output_path = os.path.join(self.icu_version, filename)
-        output_file = open(output_path, "w", encoding="utf_8")
+        output_file = open(output_path, "w", encoding="utf-8")
         json.dump(data, output_file, indent=indent)
         output_file.close()
 
@@ -132,7 +132,7 @@ class DataGenerator(ABC):
         if version:
             path = os.path.join(version, filename)
         try:
-            with open(path, "r", encoding="utf_8") as testdata:
+            with open(path, "r", encoding="utf-8") as testdata:
                 return json.load(testdata) if filetype == "json" else testdata.read()
         except BaseException as err:
             logging.warning("** readFile: %s", err)


### PR DESCRIPTION
This moves all Node errors to "unsupported" or "fail". It also outputs the actual options that NodeJS used in a failing tests.