### PR TITLE
Node and PluralRules: use supported locales in place of obsolete locales

### DIFF
--- a/executors/node/plural_rules.js
+++ b/executors/node/plural_rules.js
@@ -44,28 +44,38 @@ module.exports = {
       test_options['type'] = plural_type;
     }
 
+    let actual_locale;
     try {
       const supported_locales =
             Intl.PluralRules.supportedLocalesOf(locale, test_options);
-
-      if (!supported_locales.includes(locale)) {
-
-        return {"label": label,
-                "error" : "unusupported",
-                "unsupported": "unsupported_locale",
-                "error_detail": {'unsupported_locale': locale,
-                                 'supported_locals': supported_locales,
-                                 'test_options': test_options
-                                }
-               };
+      if (supported_locales.includes(locale)) {
+        actual_locale = locale;
+      } else {
+        if (supported_locales) {
+          actual_locale = supported_locales[0];
+        }
+        if (actual_locale == undefined) {
+          // No, there's no good substitute.
+          return {"label": label,
+                  "error" : "unusupported",
+                  "unsupported": "unsupported_locale",
+                  "error_detail": {'unsupported_locale': locale,
+                                   'supported_locals': supported_locales,
+                                   'test_options': test_options
+                                  }
+                 };
+        }
       }
     } catch (error) {
-      // Ignore for now.
+      /* Something is wrong with supporteLocalesOf */
+      return_json['error'] = 'supporteLocalesOf: ' + error.message;
+      return_json['options'] = test_options;
+      return return_json;
     }
 
     let list_formatter;
     try {
-      p_rules = new Intl.PluralRules(locale, test_options);
+      p_rules = new Intl.PluralRules(actual_locale, test_options);
     } catch (error) {
       /* Something is wrong with the constructor */
       return_json['error'] = 'CONSTRUCTOR: ' + error.message;
@@ -79,6 +89,9 @@ module.exports = {
     } catch (error) {
       return_json['error'] =
           'PLURAL RULES UNKNOWN ERROR: ' + error.message;
+    }
+    if (actual_locale != locale) {
+      return_json['actual_locale'] = actual_locale;
     }
     return return_json;
   }

--- a/schema/plural_rules/result_schema.json
+++ b/schema/plural_rules/result_schema.json
@@ -46,6 +46,10 @@
          "input_data": {
            "type": "string",
            "description": "Information provided to the executor"
+         },
+         "actual_locale": {
+           "type": "string",
+           "description": "If present, the substitute locale actually used in the test"
          }
        }
      },


### PR DESCRIPTION
#379 

Note that this PR changes Node failing tests from 77 to 87, but reduces "unsupported" from 432 to 168.
