### PR TITLE
Revert "Add more dart versions: 74, 75, and 76"

### DIFF
--- a/executors/dart_native/bin/executor.dart
+++ b/executors/dart_native/bin/executor.dart
@@ -9,12 +9,12 @@ import 'version.dart';
 
 Map<String, List<String>> supportedTests = {
   'supported_tests': [
-    'coll_shift',
+    'coll_shift_short',
   ],
 };
 
 enum TestTypes {
-  collation,
+  collation_short,
   decimal_fmt,
   datetime_fmt,
   display_names,
@@ -46,7 +46,7 @@ void main() {
           .firstWhere((type) => type.name == decoded['test_type']);
       Object result;
       switch (testType) {
-        case TestTypes.collation:
+        case TestTypes.collation_short:
           result = testCollator(decoded);
           break;
         case TestTypes.decimal_fmt:

--- a/executors/dart_native/bin/executor.dart
+++ b/executors/dart_native/bin/executor.dart
@@ -9,12 +9,12 @@ import 'version.dart';
 
 Map<String, List<String>> supportedTests = {
   'supported_tests': [
-    'coll_shift_short',
+    'collation',
   ],
 };
 
 enum TestTypes {
-  collation_short,
+  collation,
   decimal_fmt,
   datetime_fmt,
   display_names,
@@ -46,7 +46,7 @@ void main() {
           .firstWhere((type) => type.name == decoded['test_type']);
       Object result;
       switch (testType) {
-        case TestTypes.collation_short:
+        case TestTypes.collation:
           result = testCollator(decoded);
           break;
         case TestTypes.decimal_fmt:

--- a/run_config.json
+++ b/run_config.json
@@ -180,60 +180,6 @@
   {
     "prereq": {
       "name": "nvm",
-      "version": "23.3.0",
-      "command": "nvm install 23.3.0;nvm use 23.3.0 --silent"
-    },
-    "run": {
-      "icu_version": "icu76",
-      "exec": "dart_web",
-      "test_type": [
-        "collation",
-        "number_fmt",
-        "lang_names",
-        "likely_subtags"
-      ],
-      "per_execution": 10000
-    }
-  },
-  {
-    "prereq": {
-      "name": "nvm",
-      "version": "22.6.0",
-      "command": "nvm install 22.6.0;nvm use 22.6.0 --silent"
-    },
-    "run": {
-      "icu_version": "icu75",
-      "exec": "dart_web",
-      "test_type": [
-        "collation",
-        "number_fmt",
-        "lang_names",
-        "likely_subtags"
-      ],
-      "per_execution": 10000
-    }
-  },
-  {
-    "prereq": {
-      "name": "nvm",
-      "version": "21.6.0",
-      "command": "nvm install 21.6.0;nvm use 21.6 --silent"
-    },
-    "run": {
-      "icu_version": "icu74",
-      "exec": "dart_web",
-      "test_type": [
-        "collation",
-        "number_fmt",
-        "lang_names",
-        "likely_subtags"
-      ],
-      "per_execution": 10000
-    }
-  },
-  {
-    "prereq": {
-      "name": "nvm",
       "version": "20.1.0",
       "command": "nvm install 20.1.0;nvm use 20.1.0 --silent"
     },


### PR DESCRIPTION
Reverts unicode-org/conformance#385

We've encountered issues when running the pipeline from end to end, both locally and in CI. The current hypothesis is documented in #388.