### PR TITLE
Update upload-artifact version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,9 +42,9 @@ jobs:
         run: bash generateDataAndRun.sh
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: TEMP_DATA/testReports/
 


### PR DESCRIPTION
We need to fix the upload action. Here's the notice that is causing PR #393 to fail: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/