### PR TITLE
Make Dart to Node executable more robust

### DIFF
--- a/executors/dart_web/bin/make_runnable_by_node.dart
+++ b/executors/dart_web/bin/make_runnable_by_node.dart
@@ -50,7 +50,7 @@ Future<void> compile(String name, ExportFunction function) async {
   print(compile.stdout);
   print(compile.stderr);
   final outFile = File(outfileName);
-  prepareOutFile('${name}Dart', outFile, function);
+  exportFromJS('${name}Dart', outFile, function);
 }
 
 void setVersionFile() {
@@ -67,8 +67,8 @@ module.exports = { dartVersion };
   }
 }
 
-/// Prepare the file to export `testCollation`
-void prepareOutFile(String name, File outFile, ExportFunction f) {
+/// Prepare the file to export [name]
+void exportFromJS(String name, File outFile, ExportFunction f) {
   var s = outFile.readAsStringSync();
   s = s.replaceFirst('(function dartProgram() {',
       'module.exports = (function dartProgram() {');

--- a/executors/dart_web/out/executor.js
+++ b/executors/dart_web/out/executor.js
@@ -43,25 +43,6 @@ const { dartVersion } = require('./version.js')
 let doLogInput = 0;
 let doLogOutput = 0;
 
-// Test type support. Add new items as they are implemented
-const testTypes = {
-  TestCollation: Symbol("collation"),
-  TestDecimalFormat: Symbol("decimal_fmt"),
-  TestNumberFormat: Symbol("number_fmt"),
-  TestDateTimeFormat: Symbol("datetime_fmtl"),
-  TestRelativeDateTimeFormat: Symbol("relative_datetime_fmt"),
-  TestPluralRules: Symbol("plural_rules"),
-  TestDisplayNames: Symbol("display_names"),
-  TestLangNames: Symbol("language_display_name"),
-}
-
-const supported_test_types = [
-  Symbol("collation"),
-  Symbol("decimal_fmt"),
-  Symbol("number_fmt"),
-  Symbol("display_names"),
-  Symbol("language_display_name")
-];
 const supported_tests_json = {
   "supported_tests":
     [
@@ -82,33 +63,6 @@ let rl = readline.createInterface({
   output: process.stdout,
   terminal: false
 });
-
-/**
- * Given a JSON data structure, check for "test_type". If not present, then
- * infer the test ID from the label
- * !!! Not used now.
- */
-function parseJsonForTestId(parsed) {
-  let testId = parsed["test_type"];
-
-  if (testId == "collation") {
-    return testTypes.TestCollation;
-  }
-  if (testId == "decimal_fmt" || testId == "number_fmt") {
-    return testTypes.TestDecimalFormat;
-  }
-  if (testId == "display_names") {
-    return testTypes.TestDisplayNames;
-  }
-  if (testId == "language_display_name") {
-    return testTypes.TestLangNames;
-  }
-  console.log("#*********** NODE Unknown test type = " + testId);
-  return null;
-
-  // No test found.
-  return null;
-}
 
 // Read JSON tests, each on a single line.
 // Process the test and output a line of JSON results.

--- a/executors/dart_web/pubspec.yaml
+++ b/executors/dart_web/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 dev_dependencies:
   lints: ^5.1.1
   meta: ^1.16.0
+  node_preamble: ^2.0.2
   test: ^1.25.2
 
 


### PR DESCRIPTION
Make it a bit less fragile by using `package:node_preamble`.