### PR TITLE
Skip unsupported locales in plural rules test in ICU4X

### DIFF
--- a/executors/rust/2.0-beta1/Cargo.toml
+++ b/executors/rust/2.0-beta1/Cargo.toml
@@ -26,3 +26,4 @@ tinystr = "0.8.0"
 [build-dependencies]
 cargo_metadata = "0.18"
 icu_provider_source = { version = "2.0.0-beta1", default-features = false }
+serde_json = "1"

--- a/executors/rust/2.0-beta1/build.rs
+++ b/executors/rust/2.0-beta1/build.rs
@@ -1,4 +1,10 @@
 #[path = "../common/print_icu4x_versions_1_5.rs"]
 mod print_icu4x_versions_1_5;
 
-use print_icu4x_versions_1_5::main;
+#[path = "../common/print_modern_locales.rs"]
+mod print_modern_locales;
+
+pub fn main() {
+	print_icu4x_versions_1_5::main();
+	print_modern_locales::main();
+}

--- a/executors/rust/2.0-beta1/build.rs
+++ b/executors/rust/2.0-beta1/build.rs
@@ -5,6 +5,6 @@ mod print_icu4x_versions_1_5;
 mod print_modern_locales;
 
 pub fn main() {
-	print_icu4x_versions_1_5::main();
-	print_modern_locales::main();
+    print_icu4x_versions_1_5::main();
+    print_modern_locales::main();
 }

--- a/executors/rust/2.0-beta2/Cargo.toml
+++ b/executors/rust/2.0-beta2/Cargo.toml
@@ -26,3 +26,4 @@ tinystr = "0.8.0"
 [build-dependencies]
 cargo_metadata = "0.18"
 icu_provider_source = { version = "2.0.0-beta2", default-features = false }
+serde_json = "1"

--- a/executors/rust/2.0-beta2/build.rs
+++ b/executors/rust/2.0-beta2/build.rs
@@ -1,4 +1,10 @@
 #[path = "../common/print_icu4x_versions_1_5.rs"]
 mod print_icu4x_versions_1_5;
 
-use print_icu4x_versions_1_5::main;
+#[path = "../common/print_modern_locales.rs"]
+mod print_modern_locales;
+
+pub fn main() {
+	print_icu4x_versions_1_5::main();
+	print_modern_locales::main();
+}

--- a/executors/rust/2.0-beta2/build.rs
+++ b/executors/rust/2.0-beta2/build.rs
@@ -5,6 +5,6 @@ mod print_icu4x_versions_1_5;
 mod print_modern_locales;
 
 pub fn main() {
-	print_icu4x_versions_1_5::main();
-	print_modern_locales::main();
+    print_icu4x_versions_1_5::main();
+    print_modern_locales::main();
 }

--- a/executors/rust/common/print_modern_locales.rs
+++ b/executors/rust/common/print_modern_locales.rs
@@ -1,0 +1,28 @@
+// Get the list of modern locales for this ICU4X version
+
+use std::path::PathBuf;
+use icu_provider_source::{SourceDataProvider, CoverageLevel};
+
+pub fn main() {
+    let metadata = cargo_metadata::MetadataCommand::new().exec().unwrap();
+    for package in metadata.packages.iter() {
+        if package.name == "icu_provider_source" {
+            let mut path = PathBuf::from(&package.manifest_path);
+            path.pop();
+            path.push("tests");
+            path.push("data");
+            path.push("cldr");
+            let provider = SourceDataProvider::new_custom()
+                .with_cldr(&path)
+                .unwrap();
+            let locales = provider.locales_for_coverage_levels([
+                CoverageLevel::Modern
+            ]).unwrap().into_iter().map(|l| l.to_string()).collect::<Vec<_>>();
+            let locales_str = serde_json::to_string(&locales).unwrap();
+            println!(
+                "cargo:rustc-env=CONFORMANCE_ICU4X_LOCALES={}",
+                locales_str
+            );
+        }
+    }
+}

--- a/executors/rust/common/print_modern_locales.rs
+++ b/executors/rust/common/print_modern_locales.rs
@@ -1,7 +1,7 @@
 // Get the list of modern locales for this ICU4X version
 
+use icu_provider_source::{CoverageLevel, SourceDataProvider};
 use std::path::PathBuf;
-use icu_provider_source::{SourceDataProvider, CoverageLevel};
 
 pub fn main() {
     let metadata = cargo_metadata::MetadataCommand::new().exec().unwrap();
@@ -12,17 +12,15 @@ pub fn main() {
             path.push("tests");
             path.push("data");
             path.push("cldr");
-            let provider = SourceDataProvider::new_custom()
-                .with_cldr(&path)
-                .unwrap();
-            let locales = provider.locales_for_coverage_levels([
-                CoverageLevel::Modern
-            ]).unwrap().into_iter().map(|l| l.to_string()).collect::<Vec<_>>();
+            let provider = SourceDataProvider::new_custom().with_cldr(&path).unwrap();
+            let locales = provider
+                .locales_for_coverage_levels([CoverageLevel::Modern])
+                .unwrap()
+                .into_iter()
+                .map(|l| l.to_string())
+                .collect::<Vec<_>>();
             let locales_str = serde_json::to_string(&locales).unwrap();
-            println!(
-                "cargo:rustc-env=CONFORMANCE_ICU4X_LOCALES={}",
-                locales_str
-            );
+            println!("cargo:rustc-env=CONFORMANCE_ICU4X_LOCALES={}", locales_str);
         }
     }
 }

--- a/executors/rust/src/compat.rs
+++ b/executors/rust/src/compat.rs
@@ -21,3 +21,28 @@ macro_rules! pref {
 }
 
 pub(crate) use pref;
+
+#[cfg(any(ver = "1.3", ver = "1.4", ver = "1.5"))]
+pub(crate) fn is_locale_supported(_: &Locale) -> bool {
+    // Unconditionally return true so that tests will run
+    true
+}
+
+#[cfg(not(any(ver = "1.3", ver = "1.4", ver = "1.5")))]
+pub(crate) fn is_locale_supported(locale: &Locale) -> bool {
+    let json_str = std::env!("CONFORMANCE_ICU4X_LOCALES");
+    let locales: Vec<String> = serde_json::from_str(json_str).unwrap();
+    let language = locale.id.language;
+    let mut language_script = LanguageIdentifier::default();
+    language_script.language = language;
+    language_script.script = locale.id.script;
+    for candidate in locales.iter() {
+        if writeable::cmp_str(&language, candidate).is_eq() {
+            return true;
+        }
+        if writeable::cmp_str(&language_script, candidate).is_eq() {
+            return true;
+        }
+    }
+    false
+}

--- a/executors/rust/src/pluralrules.rs
+++ b/executors/rust/src/pluralrules.rs
@@ -6,7 +6,7 @@ use fixed_decimal::FixedDecimal as Decimal;
 use serde_json::{json, Value};
 use std::str::FromStr;
 
-use super::compat::{pref, Locale};
+use super::compat::{pref, is_locale_supported, Locale};
 
 // https://docs.rs/icu/latest/icu/plurals/index.html
 use icu::plurals::{PluralCategory, PluralRuleType, PluralRules};
@@ -26,6 +26,15 @@ pub fn run_plural_rules_test(json_obj: &Value) -> Result<Value, String> {
             "error_type": "locale problem",
         }));
     };
+
+    if !is_locale_supported(&locale) {
+        return Ok(json!({
+            "label": label,
+            "error_detail": {"option": locale_str},
+            "error_type": "locale problem",
+            "unsupported": "locale"
+        }));
+    }
 
     // Get number string
     let input_number = &json_obj["sample"].as_str().unwrap();

--- a/executors/rust/src/pluralrules.rs
+++ b/executors/rust/src/pluralrules.rs
@@ -6,7 +6,7 @@ use fixed_decimal::FixedDecimal as Decimal;
 use serde_json::{json, Value};
 use std::str::FromStr;
 
-use super::compat::{pref, is_locale_supported, Locale};
+use super::compat::{is_locale_supported, pref, Locale};
 
 // https://docs.rs/icu/latest/icu/plurals/index.html
 use icu::plurals::{PluralCategory, PluralRuleType, PluralRules};


### PR DESCRIPTION
Improves ICU4X plurals conformance.

However, I think we should just not emit the non-modern locales in test data gen.