### PR TITLE
Plural rules ICU4J handle known issue with '4.1'

### DIFF
--- a/executors/icu4j/74/executor-icu4j/src/test/java/org/unicode/conformance/pluralrules/icu74/PluralRulesTest.java
+++ b/executors/icu4j/74/executor-icu4j/src/test/java/org/unicode/conformance/pluralrules/icu74/PluralRulesTest.java
@@ -2,6 +2,7 @@ package org.unicode.conformance.pluralrules.icu74;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.unicode.conformance.testtype.pluralrules.PluralRulesOutputJson;
 import org.unicode.conformance.testtype.pluralrules.PluralRulesTester;
@@ -104,5 +105,17 @@ public class PluralRulesTest {
         (PluralRulesOutputJson) PluralRulesTester.INSTANCE.getStructuredOutputFromInputStr(testInput);
 
     assertEquals("unsupported", output.error);
+  }
+
+  @Ignore
+  @Test
+  public void testFloating4_1Sample() {
+    String testInput =
+        "{\"test_type\": \"plural_rules\", \"locale\":\"mk\",\"label\":\"3073\",\"type\":\"cardinal\",\"plural_type\":\"cardinal\",\"sample\":\"4.1\",\"hexhash\":\"da3b0ef6f4fa7630ff1ef134d8976ff6f80dcbbc\"}";
+
+    PluralRulesOutputJson output =
+        (PluralRulesOutputJson) PluralRulesTester.INSTANCE.getStructuredOutputFromInputStr(testInput);
+
+    assertEquals("one", output.error);
   }
 }

--- a/verifier/check_known_issues.py
+++ b/verifier/check_known_issues.py
@@ -38,7 +38,8 @@ import unicodedata
 NBSP = '\u202f'
 SP = '\u0020'
 
-floating_point_has_trailing_zero = re.compile(r"\.[^1-9]+")
+# Handles problems with floating point values with no way to indicate precision
+floating_point_has_trailing_zero = re.compile(r"\.[^2-9]+")
 
 
 # Global KnownIssue Info types and strings

--- a/verifier/check_known_issues.py
+++ b/verifier/check_known_issues.py
@@ -39,7 +39,7 @@ NBSP = '\u202f'
 SP = '\u0020'
 
 # Handles problems with floating point values with no way to indicate precision
-floating_point_has_trailing_zero = re.compile(r"\.[^2-9]+")
+floating_point_has_trailing_zero = re.compile(r"\.[^1-9]+")
 
 
 # Global KnownIssue Info types and strings
@@ -65,6 +65,7 @@ class knownIssueType(Enum):
 
     # Plural rules
     plural_rules_floating_point_sample = 'limited floating point support'
+    plural_rules_java_4_1_sample = 'ICU4J sample 4.1'
 
 
 # TODO! Load known issues from file of known problems rather than hardcoding the detection in each test
@@ -301,6 +302,9 @@ def check_plural_rules_issues(test):
         # Plural rules for floating point values may not be supported
         if floating_point_has_trailing_zero.search(sample_string):
             return knownIssueType.plural_rules_floating_point_sample
+        elif sample_string == '4.1':
+            return knownIssueType.plural_rules_java_4_1_sample
+        return None
     except KeyError as e:
         print('TEST Plural rules: %s' % test)
         return None


### PR DESCRIPTION
This should be solved with better handling of precision, but there's no public API.