### PR TITLE
DateTime: Move skeleton data to options, add new CLDR data options

### DIFF
--- a/executors/cpp/datetime_fmt.cpp
+++ b/executors/cpp/datetime_fmt.cpp
@@ -143,16 +143,16 @@ auto TestDatetimeFmt(json_object *json_in) -> string {
     }
   }
 
-  json_object *date_skeleton_obj =
-      json_object_object_get(json_in, "skeleton");
+  json_object *date_skeleton_item =
+      json_object_object_get(options_obj, "skeleton");
   string skeleton_string;
   if (date_style == icu::DateFormat::EStyle::kNone &&
       time_style == icu::DateFormat::EStyle::kNone) {
     skeleton_string = default_skeleton_string;
   }
-  if (date_skeleton_obj != nullptr) {
+  if (date_skeleton_item != nullptr) {
     // Data specifies a date time skeleton. Make a formatter based on this.
-    skeleton_string = json_object_get_string(date_skeleton_obj);
+    skeleton_string = json_object_get_string(date_skeleton_item);
   }
   if (!skeleton_string.empty()) {
     UnicodeString u_skeleton(skeleton_string.c_str());

--- a/executors/icu4j/74/executor-icu4j/src/main/java/org/unicode/conformance/testtype/datetimeformatter/DateTimeFormatterTester.java
+++ b/executors/icu4j/74/executor-icu4j/src/main/java/org/unicode/conformance/testtype/datetimeformatter/DateTimeFormatterTester.java
@@ -30,13 +30,14 @@ public class DateTimeFormatterTester implements ITestType {
 
     result.label = (String) inputMapData.get("label", null);
     result.locale_string = (String) inputMapData.get("locale", null);
-    result.skeleton = (String) inputMapData.get("skeleton", null);
 
     // The instant in UTC time.
     result.inputString = (String) inputMapData.get("input_string", null);
 
     java.util.Map<String, Object> inputOptions =
         (java.util.Map<String, Object>) inputMapData.get("options", null);
+
+    result.skeleton = (String) inputOptions.get("skeleton");
 
     result.timeZoneName = (String) inputOptions.get("timeZone");
     if (result.timeZoneName == null) {

--- a/executors/icu4j/74/executor-icu4j/src/test/java/org/unicode/conformance/datetimeformatter/DateTimeFormatterTest.java
+++ b/executors/icu4j/74/executor-icu4j/src/test/java/org/unicode/conformance/datetimeformatter/DateTimeFormatterTest.java
@@ -14,7 +14,7 @@ public class DateTimeFormatterTest {
     String testInput =
         "{\"test_type\": \"datetime_fmt\", \"input_string\":\"2024-03-07T00:00:01.00Z\","
             +
-            "\"skeleton\":\"j\",\"locale\":\"en-US\",\"options\":{\"hour\":\"numeric\",\"calendar\":\"gregory\","
+           "\"locale\":\"en-US\",\"options\":{\"hour\":\"numeric\",\"calendar\":\"gregory\",\"skeleton\":\"j\","
             +
             "\"timeZone\":\"America/Los_Angeles\",\"numberingSystem\":\"latn\"},\"hexhash\":\"30c5191c8041eb6d8afa05aab80f811753bc082f\",\"label\":\"49\"}";
 
@@ -28,7 +28,7 @@ public class DateTimeFormatterTest {
   public void TestDateTime15455() {
     String testInput =
         "{\"test_type\": \"datetime_fmt\", \"input_string\":\"2001-09-09T01:46:40.00Z\"," +
-            "\"skeleton\":\"vvvv\",\"locale\":\"zu\",\"options\":{\"timeZoneName\":\"longGeneric\","
+            "\"locale\":\"zu\",\"options\":{\"timeZoneName\":\"longGeneric\",\"skeleton\":\"vvvv\","
             +
             "\"calendar\":\"persian\",\"timeZone\":\"America/Los_Angeles\",\"numberingSystem\":\"latn\"},"
             +
@@ -76,7 +76,7 @@ public class DateTimeFormatterTest {
   public void testDateTime17387() {
     String testInput =
         "\t{\"test_type\":\"datetime_fmt\",\"input_string\":\"2001-09-09T01:46:40.01Z\"," +
-            "\"skeleton\":\"vvvv\",\"locale\":\"en\",\"options\":{\"timeZoneName\":\"longGeneric\","
+            "\"locale\":\"en\",\"options\":{\"timeZoneName\":\"longGeneric\",\"skeleton\":\"vvvv\","
             +
             "\"calendar\":\"persian\",\"timeZone\":\"Australia/Brisbane\",\"numberingSystem\":\"latn\"},"
             +
@@ -93,7 +93,7 @@ public class DateTimeFormatterTest {
   public void testDateTime5126() {
     String testInput =
         "\t{\"test_type\": \"datetime_fmt\", \"input_string\":\"1984-05-29T07:53:00.01Z\"," +
-            "\"skeleton\": \"OOOO\",\"locale\":\"zh-TW\",\"options\":{\"timeZoneName\":\"longOffset\"," +
+            "\"locale\":\"zh-TW\",\"options\":{\"timeZoneName\":\"longOffset\",\"skeleton\": \"OOOO\"," +
             "\"calendar\":\"japanese\",\"timeZone\":\"Europe/Kiev\",\"numberingSystem\":\"latn\"}," +
             "\"hexhash\":\"f44d2a93e473d0ead6b008a33aad3d2a93a2aa3c\",\"label\":\"5126\"}";
 

--- a/schema/datetime_fmt/test_schema.json
+++ b/schema/datetime_fmt/test_schema.json
@@ -35,18 +35,6 @@
            "description": "Offset in timezone from UTC",
            "type": "number"
          },
-         "datetime_skeleton": {
-           "description": "Skeleton for date/time format: https://unicode-org.github.io/icu/userguide/format_parse/datetime/",
-           "type": "string"
-         },
-         "semanticSkeleton": {
-           "description": "Semantic skeleton for date/time format",
-           "type": "string"
-         },
-         "semanticSkeletonLength": {
-           "description": "Size of semantic skeleton for date/time format",
-           "type": "string"
-         },
          "options": {
            "description": "Formatting paramters for date / time, similar to ECMAScript Intl's options bag",
            "type": "object",
@@ -131,6 +119,28 @@
                "type": "string",
                "description": "shortcut for the time style",
                "enum": ["full", "long", "medium", "short"]
+             },
+             "yearStyle": {
+               "type": "string",
+               "description": "CLDR data for year style",
+               "enum": ["with_era"]
+             },
+             "zoneStyle": {
+               "type": "string",
+               "description": "CLDR data for zone style",
+               "enum": ["generic", "specific", "location", "offset"]
+             },
+             "datetime_skeleton": {
+               "description": "Skeleton for date/time format: https://unicode-org.github.io/icu/userguide/format_parse/datetime/",
+               "type": "string"
+             },
+             "semanticSkeleton": {
+               "description": "Semantic skeleton for date/time format",
+               "type": "string"
+             },
+             "semanticSkeletonLength": {
+               "description": "Size of semantic skeleton for date/time format",
+               "type": "string"
              }
            }
          }

--- a/testgen/generators/datetime_fmt.py
+++ b/testgen/generators/datetime_fmt.py
@@ -83,26 +83,35 @@ class DateTimeFmtGenerator(DataGenerator):
                     if options['calendar'] == 'gregorian':
                         options['calendar'] = 'gregory'
 
+                if 'yearStyle' in test_item:
+                    options['yearStyle'] = test_item['yearStyle']
+                if 'zoneStyle' in test_item:
+                    options['zoneStyle'] = test_item['zoneStyle']
+
                 # Generate UTC time equivalent and get the offset in seconds
                 u_time = raw_time.astimezone(timezone.utc)
                 input_string = u_time.isoformat().replace('+00:00', 'Z')
                 tz_offset_secs = raw_time.utcoffset().total_seconds()
 
-                new_test = {"locale": test_item['locale'], "input_string": input_string, "options": options,
-                            'tz_offset_secs': tz_offset_secs, 'label': label_str,
-                            'original_input': raw_input}
                 if 'dateTimeFormatType' in test_item:
-                    new_test['dateTimeFormatType'] = test_item['dateTimeFormatType']
-
+                    options['dateTimeFormatType'] = test_item['dateTimeFormatType']
                 if 'classicalSkeleton' in test_item:
-                    new_test['skeleton'] = test_item['classicalSkeleton']
+                    options['skeleton'] = test_item['classicalSkeleton']
                 if 'semanticSkeleton' in test_item:
-                    new_test['semanticSkeleton'] = test_item['semanticSkeleton']
+                    options['semanticSkeleton'] = test_item['semanticSkeleton']
                 if 'semanticSkeletonLength' in test_item:
-                    new_test['semanticSkeletonLength'] = test_item['semanticSkeletonLength']
+                    options['semanticSkeletonLength'] = test_item['semanticSkeletonLength']
 
-                new_verify = {"label": label_str,
-                              "verify": test_item['expected']
+                new_test = {
+                    'label': label_str,
+                    'locale': test_item['locale'],
+                    'input_string': input_string,
+                    'options': options,
+                    'tz_offset_secs': tz_offset_secs,
+                    'original_input': raw_input}
+
+                new_verify = {'label': label_str,
+                              'verify': test_item['expected']
                 }
                 test_cases.append(new_test)
                 verify_cases.append(new_verify)


### PR DESCRIPTION
This updates the date time test generator to put skeleton data into options.

Also, it adds two new options yearStyle and zoneStyle from CLDR as needed by ICU4X.