### PR TITLE
Use stable version of Dart in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup version of Dart
         uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
-        with:
-          sdk: dev
       - name: Set version of Rust
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Lots of CI end-to-end workflow instances are failing in PRs and on `main`. The errors in the workflow logs only pertain to Dart, and they indicate a version that is newer. A local run of the end-to-end script succeeds successfully, and a stable version of Dart is being used.

This will turn off using unstable versions of Dart so that we still to stable ones. 

Hopefully, this will fix the noisy CI errors that are getting in the way of unrelated PRs.