### PR TITLE
Use workaround to fix many collation failures in ICU4C.

### DIFF
--- a/executors/cpp/main.cpp
+++ b/executors/cpp/main.cpp
@@ -39,7 +39,8 @@ using std::endl;
 using std::string;
 
 // Test functions
-extern auto TestCollator(json_object *json_in) -> const string;
+extern auto TestCollator(json_object *json_in,
+                         int debug_level) -> const string;
 extern auto TestDatetimeFmt(json_object *json_in) -> const string;
 extern auto TestLocaleDisplayNames(json_object *json_in) -> const string;
 extern auto TestLikelySubtags(json_object *json_in) -> const string;
@@ -62,6 +63,8 @@ extern auto TestRelativeDateTimeFmt(json_object *json_in) -> const string;
  *            test data is JSON format
  */
 auto main(int argc, const char** argv) -> int {
+  int debug_level = 0;
+
   // All the currently supported test types.
   std::vector <string> supported_tests;
   supported_tests = {
@@ -75,6 +78,15 @@ auto main(int argc, const char** argv) -> int {
     "rdt_fmt",
     "segmenter"
   };
+
+  if (argc > 1) {
+    for (int i = 1; i < argc; i++) {
+      string arg_string = argv[i];
+      if (arg_string == "DEBUG") {
+        debug_level += 1;
+      }
+    }
+  }
 
   for (std::string line; std::getline(cin, line);) {
     if (line == "#EXIT") {
@@ -115,7 +127,7 @@ auto main(int argc, const char** argv) -> int {
       std::string test_type = json_object_get_string(test_type_obj);
 
       if (test_type == "collation") {
-        outputLine = TestCollator(json_input);
+        outputLine = TestCollator(json_input, debug_level);
       } else if (test_type == "datetime_fmt") {
          outputLine = TestDatetimeFmt(json_input);
 #if U_ICU_VERSION_MAJOR_NUM >= 75

--- a/schema/collation/test_schema.json
+++ b/schema/collation/test_schema.json
@@ -40,6 +40,22 @@
             "description": "Second string for comparison",
             "type": "string"
           },
+          "s1_codes": {
+            "type": "array",
+            "description": "List hex values for characters of the string"
+            "items": {
+              "type": string,
+              "description": "hex values in string form of the Unicode value"
+            }
+          },
+          "s2_codes": {
+            "type": "array",
+            "description": "List hex values for characters of the string"
+            "items": {
+              "type": string,
+              "description": "hex values in string form of the Unicode value"
+            }
+          },
           "locale": {
             "description": "optional field indication locale tag for running test",
             "type": "string"

--- a/schema/collation/test_schema.json
+++ b/schema/collation/test_schema.json
@@ -42,7 +42,7 @@
           },
           "s1_codes": {
             "type": "array",
-            "description": "List hex values for characters of the string"
+            "description": "List hex values for characters of the string",
             "items": {
               "type": "string",
               "description": "hex values in string form of the Unicode value"

--- a/schema/collation/test_schema.json
+++ b/schema/collation/test_schema.json
@@ -50,7 +50,7 @@
           },
           "s2_codes": {
             "type": "array",
-            "description": "List hex values for characters of the string"
+            "description": "List hex values for characters of the string",
             "items": {
               "type": "string",
               "description": "hex values in string form of the Unicode value"

--- a/schema/collation/test_schema.json
+++ b/schema/collation/test_schema.json
@@ -44,7 +44,7 @@
             "type": "array",
             "description": "List hex values for characters of the string"
             "items": {
-              "type": string,
+              "type": "string",
               "description": "hex values in string form of the Unicode value"
             }
           },
@@ -52,7 +52,7 @@
             "type": "array",
             "description": "List hex values for characters of the string"
             "items": {
-              "type": string,
+              "type": "string",
               "description": "hex values in string form of the Unicode value"
             }
           },

--- a/testgen/generators/base.py
+++ b/testgen/generators/base.py
@@ -10,6 +10,7 @@ import math
 import os
 import requests
 
+
 def remove_none(obj):
     # Recursively removes any parts with None as value
     if isinstance(obj, str):
@@ -28,6 +29,7 @@ def remove_none(obj):
             result[i] = remove_none(value)
     return result
 
+
 class DataGenerator(ABC):
     def __init__(self, icu_version, run_limit=None):
         self.icu_version = icu_version
@@ -40,7 +42,6 @@ class DataGenerator(ABC):
     def process_test_data(self):
         pass
 
-
     def generateTestHashValues(self, testdata):
         # For each test item, copy it. Omit 'label' from that copy.
         # Create the string representation of that copy with json.dumps()
@@ -48,7 +49,7 @@ class DataGenerator(ABC):
         # Add it to that item.
 
         try:
-            all_tests =  testdata['tests']
+            all_tests = testdata['tests']
         except BaseException as error:
             logging.error('# generateTestHashValues: %s does not have "tests": %s',
                           error, testdata.keys())
@@ -58,7 +59,7 @@ class DataGenerator(ABC):
             try:
                 test_no_label = test.copy()
             except BaseException as error:
-                logging.error('error: %s, Item with no label found here: %s, %s' ,
+                logging.error('error: %s, Item with no label found here: %s, %s',
                               error, testdata['test_type'], test)
                 continue
             del test_no_label['label']


### PR DESCRIPTION
Test generation in Python puts SMP characters (> 0xffff) as \ud8** surrogate pairs. This works OK for ICU4J, ICU4X, and NodeJS, but fails with the current CPP JSON.

This workaround adds two new items that contain the hex codes for the characters to be compared in s1 and s2. These are set for the NON_IGNORABLE and SHIFTED data files.

This is admittedly a hack, but it points out that the tests with SMP characters were not working. With this hack, over 1200 tests now pass that were previously failing. 