### PR TITLE
ICU4X collation - mark rules as unsupported. Apply strength option.

### DIFF
--- a/executors/rust/src/collator.rs
+++ b/executors/rust/src/collator.rs
@@ -18,13 +18,57 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
     let str1: &str = json_obj["s1"].as_str().unwrap();
     let str2: &str = json_obj["s2"].as_str().unwrap();
 
+    // This may be missing
+    let compare_option: Option<&str> = json_obj["compare_type"].as_str();
+
+    let strength_option: Option<&str> = json_obj["strength"].as_str();
+
+    let rules: Option<&str> = json_obj["rules"].as_str();
+
     #[cfg(any(ver = "1.3", ver = "1.4", ver = "1.5"))]
     let mut options = CollatorOptions::new();
     #[cfg(not(any(ver = "1.3", ver = "1.4", ver = "1.5")))]
     let mut options = CollatorOptions::default();
 
-    options.strength = Some(Strength::Tertiary);
+    // Handle the given options
 
+    // Rules not yet supported.
+    if rules.is_some() {
+        return Ok(json!({
+            "label": label,
+            "error_detail": "Rules not supported",
+            "unsupported": "Collator rules not available",
+            "error_type": "unsupported",
+        }));
+    }
+
+    // Use compare_type to get < or =.
+    let mut compare_symbol = "<";  // Default
+    if let Some(comparison) = compare_option {
+        compare_symbol = &comparison[0..1];
+    } 
+
+    if let Some(strength) = strength_option {
+        options.strength = if strength == "primary" {
+            Some(Strength::Tertiary)
+        } else if strength == "secondary" {
+            Some(Strength::Secondary)
+        } else if strength == "tertiary" {
+            Some(Strength::Tertiary)
+        } else if strength == "quaternary" {
+            Some(Strength::Quaternary)
+        } else if strength == "identical" {
+            Some(Strength::Identical)
+        } else {
+            return Ok(json!({
+                "label": label,
+                "error_detail": {"strength": strength},
+                "unsupported": "strength",
+                "error_type": "unsupported",
+            }));
+        };
+    };
+    
     // Ignore punctuation only if using shifted test.
     if let Some(ip) = ignore_punctuation {
         if *ip {
@@ -32,11 +76,27 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
         }
     }
 
+    // TODO !! Iterate to find actual level of comparison, then look
+    // at compare type (1, 2, 3, 4, i, c) to see if it matches
+
     let collator = Collator::try_new(pref!(locale!("en")), options).unwrap();
 
     let comparison = collator.compare(str1, str2);
 
-    let result_string = comparison.is_le();
+    let result_string = if compare_symbol == "<" {
+        comparison.is_le()
+    } else if compare_symbol == "=" {
+        comparison.is_eq()
+    } else {
+        return Ok(json!({
+            "label": label,
+            "error_detail": {
+                "compare_type": compare_symbol,
+            },
+            "unsupported": "compare_symbol",
+            "error_type": "unsupported",
+        }));
+    };
 
     let mut comparison_number: i16 = 0;
     if comparison == Ordering::Less {
@@ -44,6 +104,7 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
     } else if comparison == Ordering::Greater {
         comparison_number = 1;
     }
+
     // TODO: Convert comparison to "<", "=", or ">"
     let json_result = json!({
         "label": label,

--- a/executors/rust/src/collator.rs
+++ b/executors/rust/src/collator.rs
@@ -43,10 +43,10 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
     }
 
     // Use compare_type to get < or =.
-    let mut compare_symbol = "<";  // Default
+    let mut compare_symbol = "<"; // Default
     if let Some(comparison) = compare_option {
         compare_symbol = &comparison[0..1];
-    } 
+    }
 
     if let Some(strength) = strength_option {
         options.strength = if strength == "primary" {
@@ -68,7 +68,7 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
             }));
         };
     };
-    
+
     // Ignore punctuation only if using shifted test.
     if let Some(ip) = ignore_punctuation {
         if *ip {

--- a/executors/rust/src/collator.rs
+++ b/executors/rust/src/collator.rs
@@ -31,7 +31,7 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
     let mut options = CollatorOptions::default();
 
     // TODO: Get and apply locale if given. Else use "und" or "en"
-    
+
     // Rules not yet supported.
     if rules.is_some() {
         return Ok(json!({

--- a/executors/rust/src/collator.rs
+++ b/executors/rust/src/collator.rs
@@ -30,8 +30,8 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
     #[cfg(not(any(ver = "1.3", ver = "1.4", ver = "1.5")))]
     let mut options = CollatorOptions::default();
 
-    // Handle the given options
-
+    // TODO: Get and apply locale if given. Else use "und" or "en"
+    
     // Rules not yet supported.
     if rules.is_some() {
         return Ok(json!({

--- a/executors/rust/src/collator.rs
+++ b/executors/rust/src/collator.rs
@@ -43,29 +43,23 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
     }
 
     // Use compare_type to get < or =.
-    let mut compare_symbol = "<"; // Default
-    if let Some(comparison) = compare_option {
-        compare_symbol = &comparison[0..1];
-    }
+    let compare_symbol = compare_option.and_then(|c| c.get(0..1)).unwrap_or("<");
 
     if let Some(strength) = strength_option {
-        options.strength = if strength == "primary" {
-            Some(Strength::Tertiary)
-        } else if strength == "secondary" {
-            Some(Strength::Secondary)
-        } else if strength == "tertiary" {
-            Some(Strength::Tertiary)
-        } else if strength == "quaternary" {
-            Some(Strength::Quaternary)
-        } else if strength == "identical" {
-            Some(Strength::Identical)
-        } else {
-            return Ok(json!({
-                "label": label,
-                "error_detail": {"strength": strength},
-                "unsupported": "strength",
-                "error_type": "unsupported",
-            }));
+        options.strength = match strength {
+            "primary" => Some(Strength::Primary),
+            "secondary" => Some(Strength::Secondary),
+            "tertiary" => Some(Strength::Tertiary),
+            "quaternary" => Some(Strength::Quaternary),
+            "identical" => Some(Strength::Identical),
+            _ => {
+                return Ok(json!({
+                    "label": label,
+                    "error_detail": {"strength": strength},
+                    "unsupported": "strength",
+                    "error_type": "unsupported",
+                }));
+            }
         };
     };
 
@@ -83,19 +77,19 @@ pub fn run_collation_test(json_obj: &Value) -> Result<Value, String> {
 
     let comparison = collator.compare(str1, str2);
 
-    let result_string = if compare_symbol == "<" {
-        comparison.is_le()
-    } else if compare_symbol == "=" {
-        comparison.is_eq()
-    } else {
-        return Ok(json!({
-            "label": label,
-            "error_detail": {
-                "compare_type": compare_symbol,
-            },
-            "unsupported": "compare_symbol",
-            "error_type": "unsupported",
-        }));
+    let result_string = match compare_symbol {
+        "<" => comparison.is_le(),
+        "=" => comparison.is_eq(),
+        _ => {
+            return Ok(json!({
+                "label": label,
+                "error_detail": {
+                    "compare_type": compare_symbol,
+                },
+                "unsupported": "compare_symbol",
+                "error_type": "unsupported",
+            }));
+        }
     };
 
     let mut comparison_number: i16 = 0;


### PR DESCRIPTION
This changes results:
  Fail:  317 --> 133
  Unsupported: 0 -> 927  (these are the tests with rules that are not yet supported)
