### PR TITLE
Fix getting data from output tables with left click with HTML escape/…

### DIFF
--- a/verifier/check_known_issues.py
+++ b/verifier/check_known_issues.py
@@ -356,7 +356,7 @@ def check_collation_issues(test):
         if (s1.find('\ufffd') >= 0 or s2.find('\ufffd') >=0 or
             ('rules' in input_data and input_data['rules'].find('\ufffd'))) >= 0:
             return knownIssueType.collation_jsonc_bug_with_surrogates
-    except KeyError as e:
+    except BaseException as e:
         return None
 
 

--- a/verifier/detail_template.html
+++ b/verifier/detail_template.html
@@ -388,7 +388,7 @@ table th {
                         } else {
                             output = item[key];
                         }
-                        html.push('<td onclick=' + onclick_call +'>' + output +'</td>');
+                        html.push('<td onclick=' + onclick_call +'>' + escapeHtml(output) +'</td>');
                     }
                 }
                 html.push("</tr>");
@@ -615,7 +615,20 @@ table th {
         }
     }
 
-    function clearSelectedItems(the_button, test_class) {
+      function escapeHtml(unsafe) {
+      // To make sure that table entries won't break the HTML code.
+      if (typeof unsafe === 'string') {
+        return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+      }
+      return unsafe;
+   }
+
+function clearSelectedItems(the_button, test_class) {
         // Clear all the check boxes for this test_class.
         const test_data = test_results[test_class];
         test_data.check_boxes.forEach((widget) => {
@@ -636,9 +649,16 @@ table th {
         }
     }
 
-    function unEscape(htmlStr) {
-        var doc = new DOMParser().parseFromString(htmlStr, "text/html");
-        return doc.documentElement.textContent;
+    function unescapeHtml(htmlStr) {
+      if (typeof htmlStr === 'string') {
+        return htmlStr
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, "''")
+        .replace(/&#039/g, "''");
+        }
+      return htmlStr;
     }
 
     // For getting contents of output into json string for testing
@@ -652,7 +672,7 @@ table th {
         }
         // alert(output);
         // Copy to clipboard.
-        navigator.clipboard.writeText(unEscape(output));
+        navigator.clipboard.writeText(unescapeHtml(output));
     }
 
     // On hover, show the difference between expected and actual result


### PR DESCRIPTION
…unescape. This resolves incomplete data being shown in test output areas because of "&", "<", etc.

Note that this uses simple replace to handle the problems expected in collation test data.