### PR TITLE
Update to use NodeJS v26.3.0 for ICU78

### DIFF
--- a/run_config.json
+++ b/run_config.json
@@ -180,6 +180,29 @@
   },
   {
     "prereq": {
+      "name": "nvm 26.3.0, icu78.1",
+      "version": "26.3.0",
+      "command": "nvm install 26.3.0;nvm use 26.3.0 --silent"
+    },
+    "run": {
+      "icu_version": "icu78",
+      "exec": "node",
+      "test_type": [
+        "collation",
+        "datetime_fmt",
+        "list_fmt",
+        "number_fmt",
+        "lang_names",
+        "likely_subtags",
+        "rdt_fmt",
+        "plural_rules",
+        "segmenter"
+      ],
+      "per_execution": 10000
+    }
+  },
+  {
+    "prereq": {
       "name": "nvm 24.0.0, icu77.1",
       "version": "24.0.0",
       "command": "nvm install 24.0.0;nvm use 24.0.0 --silent"

--- a/testgen/generators/datetime_fmt.py
+++ b/testgen/generators/datetime_fmt.py
@@ -141,6 +141,7 @@ class DateTimeFmtGenerator(DataGenerator):
     def process_test_data(self):
         # Use NOde JS to create the .json files
         icu_nvm_versions = {
+            'icu78': '26.3.0',
             'icu77': '24.0.0',
             'icu76': '23.11.0',
             'icu75': '22.9.0',

--- a/testgen/generators/list_fmt.py
+++ b/testgen/generators/list_fmt.py
@@ -13,6 +13,7 @@ class ListFmtGenerator(DataGenerator):
     def process_test_data(self):
         # Use Node JS to create the .json files
         icu_nvm_versions = {
+            'icu78': '26.3.0',
             'icu77': '24.0.0',
             'icu76': '23.11.0',
             'icu75': '22.9.0',

--- a/testgen/generators/relativedatetime_fmt.py
+++ b/testgen/generators/relativedatetime_fmt.py
@@ -14,7 +14,7 @@ class RelativeDateTimeFmtGenerator(DataGenerator):
     def process_test_data(self):
         # Use Node JS to create the .json files
         icu_nvm_versions = {
-            'icu78': '25.2.1',
+            'icu78': '26.3.0',
             'icu77': '24.0.0',
             'icu76': '23.3.0',
             'icu75': '22.9.0',

--- a/testgen/generators/segmenter.py
+++ b/testgen/generators/segmenter.py
@@ -13,6 +13,7 @@ class SegmenterGenerator(DataGenerator):
     def process_test_data(self):
         # Use Node JS to create the .json files
         icu_nvm_versions = {
+            'icu78': '26.3.0',
             'icu77': '24.0.0',
             'icu76': '23.11.0',
             'icu75': '22.9.0',


### PR DESCRIPTION
This updates the code generators and the run_config files to apply ICU78 as part of NodeJS testing.