### PR TITLE
🤖 Fix CI E2E harness bugs and shell compatibility issues

### DIFF
--- a/genData100.sh
+++ b/genData100.sh
@@ -13,7 +13,7 @@ logrotate -s logrotate.state logrotate.conf
 ##########
 
 export NVM_DIR=$HOME/.nvm;
-source $NVM_DIR/nvm.sh;
+. $NVM_DIR/nvm.sh;
 
 export RUSTUP_TOOLCHAIN=1.83
 
@@ -105,7 +105,7 @@ echo "Created $TEMP_DIR/testOutput"
 pushd testdriver
 
 # Set to use NVM
-source "$HOME/.nvm/nvm.sh"
+. "$HOME/.nvm/nvm.sh"
 
 echo "RUNNING FROM $source_file"
 

--- a/generateDataAndRun.sh
+++ b/generateDataAndRun.sh
@@ -21,7 +21,7 @@ logrotate -s logrotate.state logrotate.conf
   sleep 30
 done) &
 MONITOR_PID=$!
-trap 'kill $MONITOR_PID 2>/dev/null' EXIT
+trap 'kill $MONITOR_PID 2>/dev/null || true' EXIT
 
 ##########
 # Setup (generate) test data & expected values

--- a/testgen/generators/datetime_fmt.py
+++ b/testgen/generators/datetime_fmt.py
@@ -135,7 +135,7 @@ class DateTimeFmtGenerator(DataGenerator):
                 self.saveJsonFile(dt_test_path, test_obj, indent=2)
                 self.saveJsonFile(dt_verify_path, verify_obj, indent=2)
             except BaseException as err:
-                logging.error('!!! %s: Failure to save file %s', err, )
+                logging.error('!!! %s: Failure to save files: %s and %s', err, dt_test_path, dt_verify_path)
                 return None
 
     def process_test_data(self):
@@ -164,7 +164,7 @@ class DateTimeFmtGenerator(DataGenerator):
         # Set up Node version and call the generator
         # Add temporal to the package.
         nvm_version = icu_nvm_versions[self.icu_version]
-        generate_command = 'source ~/.nvm/nvm.sh; nvm install %s; nvm use %s --silent; npm ci; node generators/datetime_gen.js %s %s' % (
+        generate_command = '. ~/.nvm/nvm.sh; nvm install %s; nvm use %s --silent; npm ci; node generators/datetime_gen.js %s %s' % (
             nvm_version, nvm_version, '-run_limit', self.run_limit)
 
         result = subprocess.run(generate_command, shell=True)

--- a/testgen/generators/list_fmt.py
+++ b/testgen/generators/list_fmt.py
@@ -34,11 +34,11 @@ class ListFmtGenerator(DataGenerator):
 
         # Set up Node version and call the generator
         nvm_version = icu_nvm_versions[self.icu_version]
-        generate_command = 'source ~/.nvm/nvm.sh; nvm install %s; nvm use %s --silent; %s' %\
+        generate_command = '. ~/.nvm/nvm.sh; nvm install %s; nvm use %s --silent; %s' %\
                            (nvm_version, nvm_version, ' '.join(exec_list))
 
         logging.debug('Running this command: %s', generate_command)
-        result = result = subprocess.run(generate_command, shell=True)
+        result = subprocess.run(generate_command, shell=True)
 
         # Move results to the right directory
         mv_command = 'mv list_fmt*.json %s' % self.icu_version

--- a/testgen/generators/message_fmt2.py
+++ b/testgen/generators/message_fmt2.py
@@ -55,7 +55,7 @@ class MessageFmt2Generator(DataGenerator):
             try:
                 validate(src_data, json_schema)
             except ValidationError as err:
-                logging.error("Problem validating JSON: %s against schema",
+                logging.error("Problem validating JSON: %s against schema %s",
                               test_file_path, json_schema_path)
                 logging.error(err)
 

--- a/testgen/generators/relativedatetime_fmt.py
+++ b/testgen/generators/relativedatetime_fmt.py
@@ -35,10 +35,6 @@ class RelativeDateTimeFmtGenerator(DataGenerator):
             exec_list.append(str(self.run_limit))
         exec_command = ' '.join(exec_list)
 
-        nodejs_version = icu_nvm_versions[self.icu_version]
-        source_command = 'source ~/.nvm/nvm.sh; nvm run %s; %s' % (
-            nodejs_version, exec_command)
-
         if self.icu_version not in icu_nvm_versions:
             logging.warning('Generating relative date/time data not configured for icu version %s', self.icu_version)
             return False
@@ -47,7 +43,7 @@ class RelativeDateTimeFmtGenerator(DataGenerator):
 
         # Set up Node version and call the generator
         nvm_version = icu_nvm_versions[self.icu_version]
-        generate_command = 'source ~/.nvm/nvm.sh; nvm install %s; nvm use %s --silent; %s' %\
+        generate_command = '. ~/.nvm/nvm.sh; nvm install %s; nvm use %s --silent; %s' %\
                            (nvm_version, nvm_version, ' '.join(exec_list))
 
         result = subprocess.run(generate_command, shell=True)

--- a/testgen/generators/segmenter.py
+++ b/testgen/generators/segmenter.py
@@ -35,7 +35,7 @@ class SegmenterGenerator(DataGenerator):
 
         # Set up Node version and call the generator
         nvm_version = icu_nvm_versions[self.icu_version]
-        generate_command = 'source ~/.nvm/nvm.sh; nvm install %s; nvm use %s --silent; %s' %\
+        generate_command = '. ~/.nvm/nvm.sh; nvm install %s; nvm use %s --silent; %s' %\
                            (nvm_version, nvm_version, ' '.join(exec_list))
 
         logging.debug('Running this command: %s', generate_command)


### PR DESCRIPTION
This PR fixes several issues in the E2E test harness that were causing CI failures and preventing some tests from running:

1. **EXIT Trap Exit Code Pollution**: Fixes the EXIT trap in `generateDataAndRun.sh` to append `|| true` to the `kill` command, preventing exit code pollution when the monitor is already dead.
2. **Shell Compatibility (NVM Loading)**: Replaces `source` with `.` in all NVM loading commands in python generators and `genData100.sh` to ensure compatibility with `dash` (the default `/bin/sh` in Ubuntu CI). This finally enables `list_fmt`, `rdt_fmt`, `segmenter`, and `datetime_fmt` tests to run in CI (they were silently failing to generate data before).
3. **Logging Format Bug**: Fixes mismatched format string bugs in `message_fmt2.py` and `datetime_fmt.py` logging calls to prevent `TypeErrors` during error reporting.
4. **Cleanup**: Removes dead code in `relativedatetime_fmt.py` and fixes a redundant assignment typo in `list_fmt.py`.

These fixes stabilize the CI harness and ensure all tests are actually executed.