### PR TITLE
🤖 Update ICU4C and ICU4J to 78.3

### DIFF
--- a/executors/icu4j/74/executor-icu4j/pom.xml
+++ b/executors/icu4j/74/executor-icu4j/pom.xml
@@ -177,7 +177,7 @@
         <dependency>
           <groupId>com.ibm.icu</groupId>
           <artifactId>icu4j</artifactId>
-          <version>78.1</version>
+          <version>78.3</version>
         </dependency>
       </dependencies>
       <build>

--- a/run_config.json
+++ b/run_config.json
@@ -25,9 +25,9 @@
   },
   {
     "prereq": {
-      "name": "Get ICU4C 78",
-      "version": "78.1",
-      "command": "bash ../executors/cpp/set_icu4c_binary.sh ../gh-cache icu4c-78.1-Ubuntu22.04-x64.tgz icu4c-78.1-sources.tgz"
+      "name": "Get ICU4C 78.3",
+      "version": "78.3",
+      "command": "bash ../executors/cpp/set_icu4c_binary.sh ../gh-cache icu4c-78.3-Ubuntu22.04-x64.tgz icu4c-78.3-sources.tgz"
     },
     "run": {
       "icu_version": "icu78",
@@ -180,7 +180,7 @@
   },
   {
     "prereq": {
-      "name": "nvm 26.3.0, icu78.1",
+      "name": "nvm 26.3.0, icu78.3",
       "version": "26.3.0",
       "command": "nvm install 26.3.0;nvm use 26.3.0 --silent"
     },
@@ -711,8 +711,8 @@
   },
   {
     "prereq": {
-      "name": "mvn-icu4j-78-shaded",
-      "version": "78",
+      "name": "mvn-icu4j-78.3-shaded",
+      "version": "78.3",
       "command": "mvn -q -P icu78 -f ../executors/icu4j/74/executor-icu4j/pom.xml package"
     },
     "run": {

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -107,10 +107,10 @@ function download_77_1() {
   fi
 }
 
-function download_78_1() {
-  if [[ ! -f icu4c-78.1-Ubuntu22.04-x64.tgz ]]
+function download_78_3() {
+  if [[ ! -f icu4c-78.3-Ubuntu22.04-x64.tgz ]]
   then
-    wget https://github.com/unicode-org/icu/releases/download/release-78.1/icu4c-78.1-Ubuntu22.04-x64.tgz
+    wget https://github.com/unicode-org/icu/releases/download/release-78.3/icu4c-78.3-Ubuntu22.04-x64.tgz
   fi
 }
 
@@ -124,6 +124,6 @@ function download_78_1() {
  download_75_1
  download_76_1
  download_77_1
- download_78_1
+ download_78_3
 
  popd

--- a/setup_macos.sh
+++ b/setup_macos.sh
@@ -117,10 +117,10 @@ function download_77_1() {
   fi
 }
 
-function download_78_1() {
-  if [[ ! -f icu4c-78.1-sources.tgz ]]
+function download_78_3() {
+  if [[ ! -f icu4c-78.3-sources.tgz ]]
   then
-    curl -L -O https://github.com/unicode-org/icu/releases/download/release-78.1/icu4c-78.1-sources.tgz
+    curl -L -O https://github.com/unicode-org/icu/releases/download/release-78.3/icu4c-78.3-sources.tgz
   fi
 }
 
@@ -134,6 +134,6 @@ download_74_2
 download_75_1
 download_76_1
 download_77_1
-download_78_1
+download_78_3
 
 popd

--- a/testdriver/datasets.py
+++ b/testdriver/datasets.py
@@ -293,8 +293,10 @@ IcuVersionToExecutorMap = {
 # What versions of NodeJS use specific ICU versions
 # https://nodejs.org/en/download/releases/
 NodeICUVersionMap = {
+    '26.3.0': '78.3',
     '24.0.0': '77.1',
     '23.11.0': '76.1',
+    '23.3.0': '76.1',
     '22.9.0': '75.1',
     '21.6.0': '74.1',
     '20.1.0': '73.1',
@@ -313,8 +315,8 @@ ICU4XVersionMap = {
     # TODO: fill this in
     '1.0': '71.1',
     '1.61.0': '71.1',
-    '2.1': '78.1',
-    '2.2': '78.1'
+    '2.1': '78.3',
+    '2.2': '78.3'
 }
 
 ICUVersionMap = {

--- a/testgen/generators/plurals.py
+++ b/testgen/generators/plurals.py
@@ -28,6 +28,12 @@ class PluralGenerator(DataGenerator):
             cldr_git_version = 'maint/maint-44'
         elif self.icu_version == "icu75":
             cldr_git_version = 'maint/maint-45'
+        elif self.icu_version == "icu76":
+            cldr_git_version = 'maint/maint-46'
+        elif self.icu_version == "icu77":
+            cldr_git_version = 'maint/maint-47'
+        elif self.icu_version == "icu78":
+            cldr_git_version = 'maint/maint-48'
 
         cardinal_source = 'https://github.com/unicode-org/cldr/blob/%s/common/supplemental/plurals.xml' % cldr_git_version
         ordinal_source = 'https://github.com/unicode-org/cldr/blob/%s/common/supplemental/ordinals.xml' % cldr_git_version


### PR DESCRIPTION
Updates ICU4C and ICU4J executors to version 78.3 in the conformance test harness, replacing the older 78.1/78 versions to avoid overwrite conflicts. Also pins CLDR branches for plurals to avoid instability.

🤖 This pull request was created by an AI agent working with @sffc.